### PR TITLE
Add BDLS research findings and refactor notes

### DIFF
--- a/DivyanshuYadav/BDLS.md
+++ b/DivyanshuYadav/BDLS.md
@@ -1,0 +1,1909 @@
+This detailed analysis of the source code structure confirms that the transport layer for both etcdraft and SmartBFT is implemented via the general **Hyperledger Fabric Orderer cluster communication infrastructure**, which relies fundamentally on **RPC (Remote Procedure Call)** using streams, typically implemented via gRPC in Fabric.
+
+Here is a breakdown of how the transport layer is implemented and utilized, drawing on the structural components identified in the source code excerpts:
+
+### 1. The Common gRPC/RPC Transport Layer
+
+The core communication layer for all consensus algorithms (including etcdraft and SmartBFT) in the Hyperledger Fabric Orderer is centralized within the `fabric/orderer/common/cluster/` directory. This shared infrastructure provides the mechanism for nodes to communicate with each other and for clients to interact with the Orderer service:
+
+- **RPC and Streaming:** The transport mechanism is managed by core files that handle connectivity and data flow: `rpc.go`, `stream.go`, `connections.go`, and `connectionsmgr.go`. This indicates the system is designed around RPC and stream-based communication, which forms the basis of gRPC transport.
+- **Client Interface (Broadcast Stream):** Client applications submit transactions to the Orderer node using the `Broadcast` function, which returns a `Handle` function that reads requests from a **broadcast stream**. This setup facilitates **bidirectional communication** between the client and the server.
+- **Future Transition:** Although this architecture is based on RPC/streams, the sources suggest that internal consensus communication for BFT protocols may involve lower-level transports currently or in the near future. For instance, one potential improvement noted is "transitioning the communication among BDLS nodes **from using TCP connections to gRPC services**" to enhance efficiency and reliability. This implies that specialized BFT agents (like the BDLS agent found in `fabric/orderer/consensus/bdls/agent-tcp/`) might utilize or have utilized direct TCP connections for the high-frequency peer-to-peer messages, while leveraging the high-level cluster interfaces (based on gRPC/RPC) for general tasks.
+
+### 2. etcdraft Transport Implementation
+
+The etcdraft protocol, located in `fabric/orderer/consensus/etcdraft/`, utilizes the common cluster transport primarily for relaying client messages to the leader:
+
+- **Message Reception:** Client messages arrive via the Orderer's `Order()` or `Configure()` functions. These functions reside in `etcdraft/chain.go`.
+- **Encapsulation:** Both `Order()` (Listing 1, lines 2-5) and `Configure()` (Listing 2, lines 3-6) encapsulate the received client envelope (`common.Envelope`) into a `SubmitRequest` struct.
+- **Leader Forwarding (The Transport Hook):** The encapsulated message is passed to the core **`c.Submit()`** function. The critical use of the transport layer occurs here:
+    - If the Orderer node receiving the request is **not the current Raft leader** (`if lead != c.raftID`), the node forwards the request to the leader using the function **`c.forwardToLeader(lead, req)`** (Listing 4, line 5).
+    - This `forwardToLeader` call abstracts the internal cluster messaging logic, which is handled by the common Fabric cluster infrastructure using RPC/gRPC streams to ensure reliable transfer of the consensus message to the leader node.
+- **Internal Consensus Messaging:** Files like `dispatcher.go` and `disseminator.go` handle the flow of messages related to Raft operations after reception via the underlying transport.
+
+### 3. SmartBFT Transport Implementation
+
+SmartBFT (introduced in Fabric 3.0), being a Byzantine Fault Tolerant (BFT) protocol, has a communication model distinct from Raft, but relies on the same core Fabric transport abstractions:
+
+- **Client Requirement:** BFT protocols, including SmartBFT, require the client (via the SDK) to submit transactions to **all live Orderer nodes** in the quorum, unlike Raft which targets only the leader.
+- **Inter-Node Communication:** SmartBFT relies heavily on node-to-node message exchange during its consensus phases (like PRE-PREPARE, PREPARE, and COMMIT, which cause quadratic message complexity, $O(n^2)$).
+- **Code Structure for Messaging:** The internal SmartBFT logic, found in the `fabric/orderer/consensus/smartbft/` directory, handles this high volume of peer-to-peer communication through specialized modules:
+    - **`ingress.go`**: Handles incoming SmartBFT protocol messages from other nodes.
+    - **`egress.go`**: Handles outgoing SmartBFT protocol messages sent to other nodes.
+- The communication abstraction used by `ingress.go` and `egress.go` interfaces with the Fabric's cluster transport layer (RPC/gRPC) to manage the intensive message complexity required by the PBFT-family protocol.
+---
+The transport layer implementation for inter-orderer communication in both etcdraft and SmartBFT within Hyperledger Fabric leverages the generalized Fabric cluster communication architecture, which is built primarily upon **gRPC**.
+
+However, there is a notable architectural difference in how the core BDLS protocol (a version of BFT referenced in the sources) implements its transport layer compared to the standard cluster services used by etcdraft and SmartBFT.
+
+### General gRPC Transport Implementation (Used by etcdraft and SmartBFT for Inter-Orderer Messaging)
+
+Both etcdraft and SmartBFT integrate into the Fabric Orderer's robust cluster communication framework, which is managed primarily by the `cluster` package and relies on gRPC streams.
+
+1. **RPC Layer Abstraction:** Both consensus mechanisms utilize an **RPC** (`Remote Procedure Call`) component (specifically `cluster.RPC` or equivalents like the `Disseminator` in etcdraft, or the `Egress` in SmartBFT/BDLS) to send messages between orderer nodes. This RPC layer is responsible for routing messages to specific destinations based on the destination ID.
+2. **Message Encapsulation:** All messages sent between orderer nodes (both consensus-related messages and submitted transactions/requests) are wrapped within an `orderer.StepRequest` payload, which is transported over a gRPC stream. These requests are categorized by `OperationType`, either `ConsensusOperation` (for consensus protocol messages) or `SubmitOperation` (for forwarding transactions).
+3. **Stream Management:** Communication uses persistent, bidirectional gRPC streams (`Stream` objects) between cluster members, obtained via the `Step` service (`orderer.Cluster_StepClient`). The `RPC` layer manages these streams and ensures they are created as needed via `getOrCreateStream`.
+4. **Flow Control and QoS:** The `Stream` implementation includes quality-of-service logic. For consensus messages (`ConsensusRequest`), flow control is crucial: if a remote node cannot keep up (its send buffer is full), the stream can be canceled to prevent the sending node from slowing down (to avoid halting the FSM, or Finite State Machine).
+5. **Authentication and Secure Channels:** The communication management (e.g., `cluster.AuthCommMgr` used by SmartBFT) handles secure connections. When a new stream is established, the client performs node authentication using the `Auth()` function. This process involves signing a `NodeAuthRequest` and binding it to the TLS session using exported keying material (`tlsBinding`).
+
+### Specifics of etcdraft Transport
+
+The etcdraft implementation relies heavily on the `cluster.RPC` layer for sending Raft messages:
+
+- **Message Dispatch:** The core Raft messages (`raftpb.Message`) are marshaled into the payload of an `orderer.ConsensusRequest`.
+- **Metadata Dissemination:** The etcdraft chain uses a **Disseminator** wrapper around the `cluster.RPC`. The Disseminator is responsible for injecting cluster metadata (such as the list of active nodes) into the `ConsensusRequest` payload before forwarding it to the recipient, ensuring that followers receive up-to-date cluster information.
+
+### Specifics of SmartBFT Transport
+
+SmartBFT, introduced in Hyperledger Fabric 3.0, also uses the cluster gRPC infrastructure:
+
+- **Egress Component:** The SmartBFT consensus core utilizes an **Egress** component to send its protocol messages (`protos.Message`) to other nodes. The Egress converts the SmartBFT messages into the Fabric cluster `ConsensusRequest` format before passing it to the `cluster.RPC` for transmission.
+- **Ingress Component:** Incoming gRPC messages are received by the Fabric cluster service and dispatched to the SmartBFT **Ingress** component. The Ingress unmarshals the `ConsensusRequest` payload back into a SmartBFT `protos.Message` and passes it to the local consensus instance via `HandleMessage`.
+- **Communication Manager:** The SmartBFT consenter initializes the `cluster.AuthCommMgr` to handle connection setup, stream creation, and authentication with remote orderers.
+
+### Contrast with BDLS Transport
+
+While BDLS is integrated into the Fabric Orderer environment similarly to SmartBFT, the specific implementation detailed in the sources for the BDLS core consensus transport layer **does not use gRPC**; instead, it uses **raw TCP connections**:
+
+- **TCP Agent:** The BDLS implementation uses an **`agent.TCPAgent`** for managing communication between BDLS nodes.
+- **Network Setup:** The BDLS consensus logic explicitly handles network operations, including creating a TCP listener (`net.ListenTCP`) and actively dialing peers (`net.Dial`).
+- **Custom Protocol:** Communication over these TCP connections is framed with a custom message format using Protocol Buffers encapsulated in a `Gossip` message structure (which includes a 4-byte message length header). This `Gossip` protocol includes specific command types for core consensus (`CommandType_CONSENSUS`) and key authentication.
+- **Custom Authentication:** The TCP transport layer implements its own public-key authentication procedure using ECDH (Elliptic Curve Diffie-Hellman) to derive a shared secret, which is then used to generate and verify an **HMAC challenge/reply** for authentication.
+- **Future Transition:** The sources explicitly note that a potential future improvement for BDLS is "transitioning the communication among BDLS nodes from using **TCP connections** to **gRPC services**," which confirms the current implementation uses TCP for core consensus messaging.
+---
+
+The goal of refactoring the BDLS transport layer is to replace its current implementation, which relies on **raw TCP connections**, with the robust, scalable gRPC framework inherent to Hyperledger Fabric's cluster communication system. The sources confirm that a potential future improvement for BDLS is "transitioning the communication among BDLS nodes from using TCP connections to gRPC services".
+
+The existing BDLS implementation already includes the necessary components to integrate with Fabric's cluster services, indicating that the intended path is to adopt the Fabric gRPC architecture.
+
+Here is a detailed guide on how to refactor BDLS, drawing on the observed implementation patterns for both BDLS and Fabric's general cluster communication model:
+
+---
+
+## 1. Refactoring BDLS to Use Fabric's Existing gRPC Transport (Recommended Approach)
+
+The structure for Fabric consensus protocols relies on the `cluster.Communicator` interface (implemented by `cluster.AuthCommMgr` or `cluster.Comm`), which manages secure gRPC connections, and an `RPC` layer (like `cluster.RPC`) for sending messages over those connections.
+
+The BDLS implementation already initializes and utilizes these Fabric structures in its `Consenter` and `Chain` objects, making this the most practical approach.
+
+### A. Core BDLS Components Integrated with Fabric Transport
+
+The existing BDLS integration provides the necessary ingress and egress points that must be fully utilized for gRPC communication:
+
+1. **Consenter Initialization (`bdls/consenter.go`):** The BDLS `Consenter` initializes the `cluster.AuthCommMgr` (`c.Comm`) and registers the `bdls.Ingress` as the `RequestHandler` for the `cluster.ClusterService`. This setup ensures incoming gRPC requests (wrapped in `orderer.ClusterNodeServiceStepRequest`) are handled by BDLS.
+2. **BDLS Chain (`bdls/chain.go`):** The `Chain` struct already holds the necessary `Comm cluster.Communicator` object.
+3. **Egress Component (`bdls/egress.go`):** A BDLS `Egress` struct is already defined and structured to integrate the BDLS core logic with the Fabric `RPC` layer. The `Egress` implements the method `SendConsensus(targetID uint64, m *bdls.Message)` which internally uses `e.RPC.SendConsensus(targetID, bftMsgToClusterMsg(m, e.Channel))` to send the BDLS message wrapped in an `orderer.ConsensusRequest`.
+
+### B. Steps to Remove Raw TCP and Implement gRPC Message Flow
+
+The refactoring focuses on eliminating the custom TCP communication logic and ensuring the core BDLS consensus engine (`bdls.Consensus`) uses the established Fabric `Egress` object for all outgoing communication.
+
+#### Step 1: Eliminate Custom TCP Transport Logic
+
+The raw TCP setup is concentrated within the `startConsensus` function of the BDLS chain (`bdls/chain.go`):
+
+1. **Remove TCP Networking:** Delete or comment out the code that initializes the TCP listener (`net.ListenTCP`) and the active dialing loop (`net.Dial("tcp", raddr)`).
+2. **Remove `TCPAgent`:** Remove the instantiation of the `agent.NewTCPAgent` and the storage of this agent in the `Chain` struct (`c.transportLayer *agent.TCPAgent`).
+
+#### Step 2: Redirect BDLS Core Output to Fabric Egress
+
+The BDLS core protocol (`github.com/BDLS-bft/bdls`) currently sends messages using methods that rely on internal peer interfaces (`c.peers`) provided by the `TCPAgent`. This must be replaced:
+
+1. **Modify Core BDLS Broadcast/Send:** The consensus core functions (`broadcast`, `sendCommit`, and `sendTo`) must be altered to use an **Egress Interface** provided by the Fabric implementation, rather than the internal `c.peers` list.
+    - This usually involves injecting the Fabric-side `Egress` object into the BDLS core object (`bdls.Consensus`) when it is created in `NewChain`.
+2. **Implement Egress Callbacks:** The `Egress` needs to expose the network topology (list of peers/nodes via `Nodes()`) and implement the sending methods required by the core BDLS library (analogous to `SendConsensus`).
+3. **Update `startConsensus` to use Egress:** Instead of calling `c.transportLayer.Propose(data)`, the block proposal needs to be handled by the leader node through the Fabric `Egress` object, typically by broadcasting the proposed block data (`data`) to all other nodes using the Fabric `RPC` infrastructure.
+
+#### Step 3: Ensure Message Flow is via gRPC Structures
+
+The flow must now rely entirely on Fabric’s mechanism for routing consensus messages:
+
+- **Outgoing:** BDLS Core $\rightarrow$ `Egress.SendConsensus` $\rightarrow$ `cluster.RPC.SendConsensus` $\rightarrow$ gRPC Stream (via `getOrCreateStream`). The messages are wrapped in `orderer.ConsensusRequest` payloads.
+- **Incoming:** gRPC Stream $\rightarrow$ `cluster.ClusterService` $\rightarrow$ `bdls.Ingress.OnConsensus` $\rightarrow$ `bdls.Chain.HandleMessage(sender, m)`.
+
+The BDLS `Ingress` implementation is crucial here, as it performs the deserialization from the Fabric `ConsensusRequest` payload back into the native BDLS message type (`protos.Message`) before passing it to the local chain instance.
+
+---
+
+## 2. Implementing a Custom gRPC Transport Layer
+
+Implementing a custom gRPC transport layer requires significant effort to replicate the security and stream management already handled by the Fabric `cluster` package. This option is generally **not recommended** due to the need to duplicate complex security logic like **TLS session binding and node authentication**.
+
+### A. Defining Custom gRPC Services
+
+1. **Define Protocol Buffers:** Create a new `.proto` file defining a service specific to BDLS communication (e.g., `BDLSNodeService`). This service must include a remote procedure definition for message exchange, typically a bidirectional streaming RPC similar to Fabric's `Step` service (`orderer.ClusterNodeService_StepServer`).
+    - The structure of the messages should encapsulate the core BDLS messages (`bdls.Message`) while adding header information (channel ID, sender ID, etc.).
+
+### B. Implementing the gRPC Server (Ingress)
+
+1. **Server Setup:** Instantiate a standard Go gRPC server. This requires configuring **TLS/SSL** to establish secure connections.
+2. **Authentication:** This is the most complex step. You must implement custom node authentication. Fabric achieves this by requiring clients to sign an `AuthRequestSignature` payload that includes fields like `Version`, `Timestamp`, `FromId`, `ToId`, and crucially, the **TLS Session Binding** material (`SessionBinding`).
+    - The server must verify this signed request against the client's identity certificate presented in the TLS handshake.
+3. **Message Reception:** Implement the streaming RPC handler (e.g., `BDLS_Step`). This handler must:
+    - Receive the incoming messages.
+    - Deserialize the wrapper message and extract the raw BDLS consensus message.
+    - Pass the raw BDLS message to the local `bdls.Consensus` instance using methods like `ReceiveMessage(bts []byte, now time.Time)`.
+
+### C. Implementing the gRPC Client (Egress)
+
+1. **Client Connection Management:** You must create a client-side component (similar to `cluster.ConnectionsMgr`) responsible for:
+    - Resolving remote BDLS node endpoints (`EndpointCriteria`).
+    - Establishing secure gRPC client connections (`grpc.ClientConn`) using the appropriate mutual TLS configurations.
+2. **Stream Management:** Manage persistent bidirectional streams to each peer. This includes:
+    - Creating a new stream (`BDLSNodeService.Step()`).
+    - Executing the **custom authentication handshake** (`Auth()` function equivalent) on the new stream.
+    - Handling stream failures (EOF, network errors) by closing and automatically recreating the stream.
+3. **Sending Logic:** Write the core BDLS message output to the established stream. The messages must be marshaled, wrapped in the custom transport message format, and transmitted using the stream's `Send()` method.
+
+The existing BDLS integration code demonstrates a clear intention to use the robust `cluster` layer already available in Fabric. Reverting to raw TCP was likely done because the BDLS core library itself was not originally designed for the Fabric gRPC layer, leading to the use of an intermediate `agent-tcp` layer. Fully adopting the Fabric gRPC architecture involves bridging this gap by replacing the `agent-tcp` interface layer with the Fabric `Egress` and `RPC` structures.
+
+---
+The SmartBFT (Byzantine Fault-Tolerant Smart) protocol, utilized as a BFT ordering service in Hyperledger Fabric (specifically Fabric v3.0), relies heavily on **gRPC** for secure, high-performance communication between ordering nodes.
+
+SmartBFT, which is based on the BFT-SMART and PBFT (Practical Byzantine Fault Tolerance) protocols, exhibits a **quadratic message complexity ($O(N^2)$)**, meaning the communication overhead scales rapidly with the number of nodes ($N$).
+
+The gRPC communication architecture in SmartBFT/Fabric is implemented via the **Cluster Service** and specialized communication managers that handle authenticated streams.
+
+### 1. gRPC Communication Mechanisms
+
+The SmartBFT consensus library (specifically the Go implementation) is integrated directly into the Fabric Ordering Service Node (OSN). Communication flows utilize defined Fabric interfaces that leverage gRPC:
+
+1. **Transport Layer (RPC):** The core mechanism for sending consensus messages is the `RPC` interface, which provides the `SendConsensus` function. This RPC layer manages the actual gRPC connections and streams (`Stream`).
+2. **Egress (Outgoing Messages):** The SmartBFT `Egress` component encapsulates the consensus protocol messages (like PRE-PREPARE, PREPARE, COMMIT) into Fabric's standard message wrapper, the `orderer.ConsensusRequest`. The `SendConsensus` function then transmits this wrapper via gRPC to the designated target node ID. The system must handle both consensus messages (`ConsensusOperation`) and client submission messages (`SubmitOperation`).
+3. **Ingress (Incoming Messages):** The receiving node utilizes the `ClusterService` registered with the main gRPC server. When a message arrives, the `Ingress` component identifies the channel and sender ID. If it is a consensus message (`orderer.ConsensusRequest`), the payload (containing the marshaled SmartBFT protocol message) is unmarshaled and passed to the appropriate chain's `HandleMessage` function for protocol processing.
+4. **Security and Authentication:** Communication between nodes is handled by the `AuthCommMgr` (Authenticated Communication Manager), which ensures authenticated point-to-point channels are established using client-side gRPC connections. Nodes must possess authenticated identities (e.g., client TLS certificates) to communicate.
+
+### 2. SmartBFT Protocol Flow with 4 Consenter Example
+
+In the SmartBFT protocol, a normal consensus instance requires three distinct broadcast phases after the initial client request: PRE-PREPARE, PREPARE, and COMMIT.
+
+We examine a cluster of $N=4$ consenters: $P_0, P_1, P_2, P_3$. In a BFT system, this setup tolerates $t=1$ fault ($N = 3t + 1$), requiring a quorum ($Q$) of $2t + 1 = 3$ nodes to achieve consensus.
+
+The total message complexity for consensus in this model (including client submission) is calculated as $2N^2 + N$. For $N=4$, this equals $2(4^2) + 4 = 36$ total messages.
+
+We assume $P_0$ is the current **Leader**.
+
+#### Phase 0: Client Submission (Request)
+
+1. **Client Submits Transaction:** A client (using the SDK, modified to interact properly with a BFT service) sends the transaction proposal (wrapped in an `Envelope`) to **all $N=4$ orderers** ($P_0, P_1, P_2, P_3$). This uses the `orderer.SubmitRequest`.
+    - **gRPC Action:** Client initiates RPC, sending a `SubmitRequest` to each orderer node's ingress point.
+    - **Message Count:** $N = 4$ messages.
+
+#### Phase 1: Leader Proposal (PRE-PREPARE)
+
+This phase ensures all nodes agree on the proposed order/content ($B'$, the block to be committed) for a specific sequence number and view.
+
+1. **Leader $P_0$ Prepares Proposal:** $P_0$ collects client requests, batches them, and assembles a proposal (block $B'$).
+2. **Leader $P_0$ Broadcasts PRE-PREPARE:** $P_0$ initiates the consensus sequence by broadcasting a **PRE-PREPARE** message containing the proposed block $B'$ to all $N=4$ nodes.
+    - **gRPC Action:** The SmartBFT consensus library calls the `Comm` (via the `Egress` wrapper) which uses `RPC.SendConsensus` to send the `ConsensusRequest` containing the marshaled message to all 4 destinations.
+    - **Message Count:** $N = 4$ messages (P0 $\rightarrow P_0, P_1, P_2, P_3$).
+
+#### Phase 2: Agreement (PREPARE)
+
+This phase ensures that enough replicas have agreed on the ordering of the message within the current view.
+
+1. **Followers Validate and Broadcast PREPARE:** Upon receiving the PRE-PREPARE message, each node $P_j$ (including $P_0$) performs validation checks (since followers cannot trust the leader in a BFT environment). Each node then sends a signed **PREPARE** message to **all $N=4$ nodes**.
+    - **gRPC Action:** Each of the 4 nodes performs a broadcast operation using `RPC.SendConsensus`.
+    - **Message Count:** $N \times N = 4 \times 4 = 16$ messages.
+
+#### Phase 3: Final Confirmation (COMMIT)
+
+Once a node collects $Q=3$ matching PREPARE messages, it enters the COMMIT phase.
+
+1. **Nodes Broadcast COMMIT:** Each node $P_j$ sends a signed **COMMIT** message to **all $N=4$ nodes** to confirm the final decision.
+    - **gRPC Action:** Each of the 4 nodes performs a broadcast operation using `RPC.SendConsensus`.
+    - **Message Count:** $N \times N = 4 \times 4 = 16$ messages.
+
+#### Phase 4: Decision (DELIVER)
+
+1. **Quorum Reached:** When any node receives $Q=3$ matching COMMIT messages, it has reached consensus (the "decision").
+2. **Block Delivery:** The node delivers the committed proposal (block) along with the $Q$ commit signatures to the application layer (the Fabric ledger) for permanent storage.
+
+**Summary of Communication for $N=4$ SmartBFT Consensus:**
+
+|Phase|Description|Recipients|Messages Sent|
+|:--|:--|:--|:--|
+|0|Client Request|All $N$ nodes|$N$ (4)|
+|1 (PRE-PREPARE)|Leader Proposal|All $N$ nodes (Broadcast)|$N$ (4)|
+|2 (PREPARE)|All nodes agree|All $N$ nodes (Broadcast by $N$)|$N^2$ (16)|
+|3 (COMMIT)|All nodes confirm|All $N$ nodes (Broadcast by $N$)|$N^2$ (16)|
+|**Total gRPC Messages**|||**36** ($2N^2 + N$)|
+
+This example clearly illustrates the quadratic messaging overhead in SmartBFT, where the majority of communication (32 messages out of 36 total) occurs during the all-to-all broadcast phases (PREPARE and COMMIT).
+
+---
+The implementation of the **Client Submission Phase** in a BDLS (Blockchain version of DLS) enabled Hyperledger Fabric ordering service follows a specific pattern required by Byzantine Fault-Tolerant (BFT) systems, utilizing **gRPC** for client-to-orderer communication. The requirement is that the client must submit the transaction proposal to **all BDLS nodes** to protect against censorship attacks by malicious orderers.
+
+Here is an explanation of how this client submission is implemented, focusing on the data structures and relevant code references within the Fabric BDLS integration framework.
+
+### 1. Client Requirement and BFT Rationale
+
+In a BFT ordering service like BDLS, the client (using the Fabric SDK) is modified to ensure that **every transaction is submitted to all orderers**. This is done to prevent censorship by a potentially malicious orderer, a crucial BFT concern.
+
+The client's primary goal in this phase is to send the endorsed transaction (wrapped in an `Envelope`) to all $N=4$ orderer nodes ($P_0, P_1, P_2, P_3$).
+
+### 2. The Data Structures (Protocol Buffers)
+
+The client's transaction proposal flows through several Protocol Buffer definitions as it moves from the client to the orderer's internal consensus logic via gRPC:
+
+1. **Client Transaction:** The client has already collected endorsements and assembled the transaction, which is packaged as a `common.Envelope`. The `Envelope` wraps the payload and includes a signature for authentication.
+2. **gRPC Request Payload:** The `Envelope` is encapsulated within an `orderer.SubmitRequest`. This is the actual message sent via gRPC from the client to the orderer.
+3. **Orderer Internal Wrapper:** When the orderer receives this `SubmitRequest`, it is often wrapped internally by the consensus layer (e.g., in a `submit` struct in the chain logic) for channel-based processing.
+
+### 3. Implementation Flow and gRPC Action
+
+The entire client submission process is handled via gRPC Remote Procedure Calls (RPCs).
+
+|Step|Action/Component|Data Type|gRPC Role|
+|:--|:--|:--|:--|
+|**Client Send**|Client SDK/Library|`orderer.SubmitRequest`|Initiates gRPC call (RPC)|
+|**Orderer Receive**|Orderer's `ClusterService` (Ingress)|`orderer.ClusterNodeServiceStepRequest`|Listens for incoming RPC|
+|**Message Dispatch**|`Ingress` Handler|`orderer.SubmitRequest` (Unwrapped)|Passes message to the BDLS chain|
+|**Chain Processing**|BDLS `Chain.Submit()`|`submit` struct containing `Envelope`|Queues request for ordering|
+
+#### A. Client-Side gRPC Interaction
+
+The client initiates the gRPC call. Although the sources describe the requirement for the client to submit the transaction to **all orderers**, the specific client-side SDK code for simultaneously addressing $P_0, P_1, P_2, P_3$ is not detailed, but the effect is $N=4$ individual gRPC requests sent.
+
+#### B. Orderer-Side gRPC Ingress (Receiving the Request)
+
+Each orderer node ($P_j$) runs a gRPC server that exposes the `ClusterNodeService` (or similar service). The incoming message is handled by the server's `Step` function.
+
+1. **Request Type Recognition:** When the request arrives, the `ClusterService` determines if the message is a transaction request (`NodeTranrequest`) or a consensus message (`NodeConrequest`). Since the client sends a transaction proposal, it arrives as a `NodeTranrequest`, which corresponds to an embedded `orderer.SubmitRequest`.
+2. **Channel and Sender Identification:** The cluster communication layer (`Comm` or `ClusterService`) must identify the target channel and authenticate the sender (client or another node) using TLS certificates.
+3. **Dispatch to Handler:** The message is dispatched to the BDLS component via the `RequestHandler` interface (specifically the `Ingress` implementation).
+
+The relevant ingress function handling the client transaction submission is the `OnSubmit` method, which is implemented in the BDLS package's `Ingress` type.
+
+**Code Snippet: BDLS Ingress Handling the Client Submission** (Conceptual implementation of `OnSubmit`)
+
+The `Ingress` structure acts as the bridge between the gRPC transport layer and the internal BDLS consensus logic.
+
+```
+// BDLS Ingress and Message Handling
+
+// Ingress dispatches Submit and Step requests to the designated per chain instances
+type Ingress struct {
+    Logger WarningLogger
+    ChainSelector ReceiverGetter
+}
+
+// OnSubmit notifies the Ingress for a reception of a SubmitRequest from a given sender on a given channel
+func (in *Ingress) OnSubmit(channel string, sender uint64, request *ab.SubmitRequest) error {
+
+    // 1. Locate the correct BDLS chain instance for the channel ID
+    receiver := in.ChainSelector.ReceiverByChain(channel)
+
+    if receiver == nil {
+        in.Logger.Warningf("An attempt to submit a transaction to a non existing channel (%s) was made by %d", channel, sender)
+        return errors.Errorf("channel %s doesn't exist", channel)
+    }
+
+    // 2. Extract the payload (the signed common.Envelope) from the SubmitRequest
+    // The payload contains the transaction proposal (Envelope)
+    payloadBytes := protoutil.MarshalOrPanic(request.Payload)
+
+    // 3. Forward the request payload (the Envelope bytes) to the BDLS chain's request handler
+    // BDLS Chain implements MessageReceiver
+    receiver.HandleRequest(sender, payloadBytes)
+
+    return nil
+}
+```
+
+#### C. BDLS Chain Submission Logic
+
+Once the `Ingress.OnSubmit` calls `HandleRequest` on the BDLS chain instance, the message enters the consensus mechanism.
+
+The BDLS `Chain` implementation receives the message, verifies it, wraps it as a `submit` internal struct, and sends it to the processing channel `c.submitC`.
+
+**Code Snippet: BDLS Chain Submitting the Request** (Implementation of `submit` function used by `Chain.Order`)
+
+The `submit` function wraps the incoming transaction (`env`) into an `orderer.SubmitRequest` and places it onto a channel for asynchronous processing by the `run` loop:
+
+```
+// BDLS Consensus Implementation for Orderer (Chain.submit)
+
+func (c *Chain) submit(env *common.Envelope, configSeq uint64) error {
+    /*if err := c.isRunning(); err != nil {
+    c.Metrics.ProposalFailures.Add(1)
+    return err
+    }*/
+
+    // 1. Create the SubmitRequest object, containing the Envelope (Payload) and Channel ID
+    req := &orderer.SubmitRequest{LastValidationSeq: configSeq, Payload: env, Channel: c.Channel}
+
+    // 2. Queue the internal 'submit' struct onto the dedicated channel
+    select {
+    case c.submitC <- &submit{req}:
+        return nil
+    case <-c.doneC:
+        c.Metrics.ProposalFailures.Add(1)
+        return errors.Errorf("chain is stopped")
+    }
+}
+```
+
+This ensures that the raw transaction data submitted by the client is successfully ingested into the BDLS orderer's internal queue (`c.submitC`) for processing, leading ultimately to block creation and proposal (`c.propose`).
+
+----
+raising a crucial point regarding the implementation status and choice of communication protocol for the BDLS consensus integration within Hyperledger Fabric. Based on the provided source material, your observation is accurate: the **BDLS Proof of Concept (POC) implementation does not use Fabric's standard gRPC cluster communication mechanisms but instead utilizes a custom TCP agent for peer-to-peer BDLS message exchange**.
+
+The documentation for BDLS explicitly suggests that **transitioning the communication among BDLS nodes from using TCP connections to gRPC services is a potential area for future enhancement**.
+
+Here is a detailed analysis of what BDLS is currently missing in its transport layer implementation, the necessary changes for refactoring, associated challenges, and recommended steps for engagement and learning.
+
+---
+
+## 1. Missing Components and Gaps in the Current BDLS Transport Layer
+
+The BDLS implementation uses a specialized `agent-tcp` package (`agent` package) for consensus communication, which bypasses the robust, production-grade cluster communication framework utilized by Raft and SmartBFT.
+
+### A. Missing Fabric Cluster Communication Integration
+
+The BDLS implementation directly relies on **raw TCP connections and a custom TCP agent** (`agent.TCPAgent`) for sending and receiving internal consensus messages (`bdls.Message`). This contrasts sharply with standard Fabric ordering services (like SmartBFT and Raft) which use the shared `cluster` package and **gRPC** for authenticated, secure, streaming communication.
+
+1. **gRPC Transport Layer:** BDLS lacks the core Fabric `cluster.RPC` interface implementation for consensus message sending (`SendConsensus`). Instead, the BDLS `Chain` starts an independent `TCPAgent` that manually manages listener setup (`net.ListenTCP`) and connections (`net.Dial`).
+2. **Authenticated/TLS Channel Management:** While the core BDLS protocol defines authentication methods like `InitiatePublicKeyAuthentication()` using elliptic curve cryptography and challenge-reply protocols over TCP, it does not leverage Fabric's dedicated, highly configurable **`cluster.AuthCommMgr`** or `comm.ServerConfig` which are designed to handle authenticated gRPC connections using Fabric identities (MSPs and TLS certificates).
+3. **Standardized Message Dispatch (Ingress/Egress):** Although BDLS has `Ingress` and `Egress` components defined, the internal consensus message transmission within the `Consensus` object uses the custom `TCPAgent` via `consensus.ReceiveMessage(msg, time.Now())` and manual broadcasts. The `Egress` component relies on the `cluster.RPC` interface, which would need to be integrated with the custom TCP layer if not refactored. The core BDLS consensus object handles `broadcast` and `sendTo` directly over its defined `peers` (`PeerInterface`), which are implemented by `TCPPeer` objects.
+4. **Security and Authentication:** The BDLS implementation includes a custom key authentication mechanism using `KeyAuthInit`, `KeyAuthChallenge`, and `KeyAuthChallengeReply` over its raw `Gossip` TCP stream. This proprietary implementation handles public key verification and HMAC calculation. Production Fabric implementations use gRPC secured by **TLS client certificates** for mutual authentication, which is handled generically by the `cluster.AuthCommMgr`. The BDLS TCP approach requires independent security management from the main Fabric cluster framework.
+
+### B. BDLS's Proposed Future Refactoring
+
+The need for a refactoring to gRPC is acknowledged in the context of improving the protocol: "One potential improvement is **transitioning the communication among BDLS nodes from using TCP connections to gRPC services**. gRPC, with its advantages in performance and scalability, could further enhance the efficiency and reliability of BDLS’s communication protocol".
+
+## 2. Changes Needed for Refactoring the Transport Layer
+
+To refactor the BDLS transport layer to align with SmartBFT and Raft's production architecture, the following changes are necessary:
+
+### A. Modifying the BDLS Chain Implementation (`chain.go`)
+
+1. **Remove Custom TCP Agent:** Eliminate the instantiation and management of the custom `agent.TCPAgent` and the direct listener/dialer setup (`net.ResolveTCPAddr`, `net.ListenTCP`, `net.Dial`) within `c.startConsensus`.
+2. **Integrate Fabric `RPC` Interface:** The BDLS `Chain` struct must be initialized with the production-grade Fabric **`cluster.RPC` interface** (or its wrapper, such as `cluster.AuthCommMgr` or the `Egress` struct, which contains the `RPC`).
+3. **Update Consensus Object Integration:** The core BDLS `Consensus` object needs an updated way to output messages that utilizes the `RPC` layer instead of relying on its internal `peers` list and `broadcast()` function.
+    - In production Fabric BFT protocols, the consensus library's `Comm` interface is implemented by the `Egress` component, which uses `RPC.SendConsensus` to wrap and send messages. BDLS would require its `bdls.Consensus` object to be configured to route outgoing messages through its custom `Egress` implementation, which then uses the Fabric `RPC`.
+
+### B. Implementing gRPC-based Egress/Ingress
+
+1. **Egress Refactoring:** The existing `Egress` struct must fully rely on the provided Fabric `cluster.RPC` to send messages. When the internal BDLS core wants to send a message `m` to `targetID`, the `Egress.SendConsensus` method must:
+    - Marshal the internal `bdls.Message` into the payload of a Fabric `orderer.ConsensusRequest`.
+    - Call `e.RPC.SendConsensus(targetID, clusterMsg)`.
+2. **Ingress Refactoring:** The `Ingress` component is already structured to receive standard Fabric `orderer.ConsensusRequest` messages via gRPC. This structure is shared with SmartBFT/Raft and should remain. It receives the request, unmarshals the payload back into a `bdls.Message`, and calls `receiver.HandleMessage(sender, msg)`. The Fabric cluster service (`cluster.ClusterService` or similar) automatically handles receiving the request and calling the `Ingress` handler.
+
+### C. Leveraging Fabric’s Security and Connection Management
+
+1. **Adopt `AuthCommMgr`:** BDLS must configure the `cluster.AuthCommMgr` to manage connections and certificates, replacing its custom key exchange logic. This ensures security compliance with the rest of the Fabric network, which mandates authenticated point-to-point channels.
+2. **Node Configuration:** Ensure the BDLS `Consenter` configuration properly updates node endpoints and certificates via the `Comm` object using `c.Comm.Configure(c.support.ChannelID(), nodes)`.
+
+## 3. Challenges in Refactoring the Transport Layer
+
+Refactoring the BDLS transport layer presents several technical challenges inherent to migrating a custom protocol implementation into a standardized framework:
+
+1. **Decoupling Custom TCP/Crypto:** The core BDLS consensus logic (`bdls/consensus/bdls/core.go`) is currently tightly coupled with its custom communication and cryptographic functions (e.g., `broadcast`, `sendTo`, `SignedProto` marshalling/unmarshalling). This requires a clean separation where the core consensus object solely focuses on state machine logic and delegates all network I/O and cryptographic primitives to injected interfaces.
+2. **Cryptography Delegation:** The BDLS library uses specific cryptography definitions (`SignedProto` based on `PubKeyAxis`, `blake2b` hashing, and `btcec.S256()` curve) for message signing and proof verification. Fabric’s internal signing and verification typically rely on the **`SignerSerializer`** and **BCCSP** interfaces. The refactored gRPC layer must ensure that the outgoing messages are signed using the BDLS mechanism _before_ being wrapped into the `ConsensusRequest`, and that incoming messages are passed to the BDLS verifier for cryptographic checks. BDLS already exposes `SignProposal` and `VerifySignature` concepts.
+3. **Synchronization and Timing Model:** The existing BDLS implementation uses an **active update tick** (e.g., `updateTick := time.NewTicker(updatePeriod)`) that manually calls `c.transportLayer.Update()` every 20ms to process messages and timeouts. Integrating with gRPC means relying on asynchronous stream processing. The synchronization mechanism must be adapted to respond immediately to incoming gRPC messages (`OnConsensus` calls the handler, which feeds the consensus object) while still relying on the internal tick for timeouts and leader election logic.
+4. **BFT Security Validation:** BFT protocols require specialized policies. SmartBFT introduced the necessary end-to-end BFT policies for peers and orderers, including the requirement that blocks be signed by a quorum ($Q=2t+1$) of nodes. BDLS must ensure that after refactoring the communication, all security requirements related to key authentication, signature handling, and block validation remain compliant with the BDLS protocol requirements and Fabric's BFT validation policy.
+
+## 4. What Can I Do? How Can I Do It?
+
+If you intend to contribute to the BDLS integration or undertake this refactoring, here are actionable steps:
+
+### A. What Can I Do? (Goals)
+
+1. **Replace Custom Network Stack:** Eliminate the custom TCP listener and dialer implementation in `bdls/chain.go` and `bdls/agent-tcp`.
+2. **Integrate Standard Fabric RPC:** Route all BDLS consensus messages through the standard `cluster.RPC` interface using `SendConsensus`.
+3. **Maintain Protocol Security:** Ensure that Fabric's underlying TLS/gRPC security provides the authenticated channels required, replacing the need for the custom public key authentication handshake over raw TCP.
+4. **Validate BDLS Linear Scalability:** Once refactored, re-run performance benchmarks to confirm that the linear message complexity advantage of BDLS ($O(N)$ vs. SmartBFT's $O(N^2)$) is preserved or enhanced by gRPC's efficiency.
+
+### B. How Can I Do It? (Actionable Steps)
+
+1. **Define `bdls.Comm` Interface:** Create a clean interface for communication (e.g., `BDLSNetwork`) that encapsulates the `SendConsensus` logic required by the core BDLS protocol.
+2. **Implement `BDLSNetwork` using `Egress`:** Write a new implementation of this interface that wraps the existing `bdls.Egress` layer, ensuring it correctly marshals `bdls.Message` objects into `orderer.ConsensusRequest` objects and calls the Fabric `RPC`.
+3. **Inject Dependencies:** Modify the core BDLS `Consensus` object creation (`bdls.NewConsensus`) to accept this new communication implementation rather than directly instantiating internal peer connections.
+4. **Refactor `bdls/chain.go`'s `startConsensus`:** Remove all code related to `agent.NewTCPAgent`, `net.ListenTCP`, and `net.Dial`. Instead, initialize the `Egress` object with the `cluster.RPC` available through the `Consenter` structure, and pass this communication object (or its wrapper) to `bdls.NewConsensus`.
+5. **Review Client Submission:** Verify that the client request handling (which uses `HandleRequest`) correctly feeds raw request bytes to `c.consensus.SubmitRequest(req, time.Now())`. This integration point likely already uses the standard Fabric `Ingress.OnSubmit` handler which processes client requests received via the gRPC stream.
+
+## 5. What Are the Things I Need to Learn First?
+
+To successfully execute this refactoring, a foundational understanding of distributed systems implementation in Go and Hyperledger Fabric's internal structure is essential:
+
+1. **Hyperledger Fabric Orderer Architecture:** Understand the **pluggable nature of consensus** in Fabric, specifically how `Consenter` and `Chain` interfaces are implemented, and how messages flow from clients/peers through the `Ingress`/`Egress` components.
+2. **Go gRPC and Protocol Buffers:** Master how **gRPC streams** (`Cluster_StepClient`) are utilized in Fabric's cluster communication and how Protocol Buffers (like `orderer.ConsensusRequest`) are marshalled and unmarshalled for network transmission. The process of **unmarshaling blocks** and handling large payloads is a critical performance factor in Fabric.
+3. **Fabric Cluster Communication (`cluster` Package):** Deeply understand the functionality of `cluster.RPC`, `cluster.AuthCommMgr`, `cluster.RemoteContext`, and how the communication endpoints (`cluster.RemoteNode`) and security features (TLS, authenticated channels) are managed in Fabric.
+4. **BFT Protocol Mechanics (BDLS/PBFT):** Understand the core message exchange phases (Request, Propose/Lock, Commit, Decide) and the specific requirements of BDLS (linear message complexity, proofs, and round changes) to ensure the refactoring maintains protocol correctness.
+5. **Go Concurrency:** Since consensus nodes rely heavily on concurrent goroutines and channels (e.g., `submitC`, `applyC`, `haltC`) for internal state management and I/O handling, expertise in Go concurrency models is necessary to manage the asynchronous nature of gRPC streams correctly within the consensus loop (`c.run()` and `c.startConsensus`).
+
+
+----
+
+
+## 1. Protocol Buffers: Defining the Data Structure
+
+**Protocol Buffers (Protobuf)** are a language-neutral, platform-neutral, extensible mechanism for serializing structured data. They define the format of the messages exchanged between components, ensuring efficient and reliable transmission.
+
+### A. Core Concepts and Serialization
+
+In the context of the BDLS consensus POC, message definitions are crucial.
+
+1. **Message Definition (Schema):** Messages are defined using a specific syntax (e.g., `syntax = "proto3"`). These definitions specify the fields and their types. For example, the custom BDLS agent protocol defines a `Gossip` message:
+    
+    ```Go
+    message Gossip{
+    CommandType Command = 1;
+    bytes Message=2;
+    }
+    ```
+    
+    This message contains a `CommandType` (an `enum`) and a `bytes` field named `Message`. The fields are assigned sequential numbers (1 and 2), which are used for serialization.
+2. **Serialization (Marshalling):** Once a message is instantiated in Go (e.g., a `bdls.Message` or `orderer.SubmitRequest`), it must be converted into a binary format (a byte slice) for network transmission or persistent storage. This process is called **marshalling** or serialization.
+    - The `proto.Marshal` function in Go is used extensively for this purpose. For instance, BDLS components marshal data: `out, err := proto.Marshal(sp)` or `date, err := proto.Marshal(m)`.
+    - Hyperledger Fabric components utilize helper functions like `protoutil.MarshalOrPanic(message)` to serialize Protocol Buffer messages (like the payload of an `orderer.ConsensusRequest`).
+3. **Deserialization (Unmarshalling):** Upon reception, the binary byte slice is converted back into a usable Go struct. This is **unmarshalling**.
+    - This is done using `proto.Unmarshal`. For example, when a `ConsensusRequest` arrives, the BDLS `Ingress` component attempts to unmarshal the payload back into a `bdls.Message` struct: `if err := proto.Unmarshal(request.Payload, msg); err != nil {...}`.
+
+### B. BDLS Custom Protobuf Use (Example)
+
+In the BDLS POC, the TCP agent uses a `Gossip` Protobuf structure to encapsulate various commands, including `KEY_AUTH_INIT`, `KEY_AUTH_CHALLENGE`, and the actual `CONSENSUS` message.
+
+When sending a consensus message, the data is structured as follows:
+
+1. The core BDLS message (`bdls.Message`) is signed cryptographically by the sender, producing a `SignedProto`.
+2. The `SignedProto` is marshaled into raw bytes.
+3. These bytes are wrapped as the `Message` field inside the `Gossip` message, and the `Command` field is set to `CONSENSUS`.
+4. The final `Gossip` message is marshaled, prefixed with its length (4 bytes), and sent over the raw TCP connection.
+
+## 2. Go gRPC: The Communication Framework
+
+**gRPC** is an RPC (Remote Procedure Call) framework that uses Protobuf for defining service interfaces and message exchange. In Hyperledger Fabric (used by production consensus engines like Raft and SmartBFT), gRPC provides the foundation for secure, high-performance inter-node communication.
+
+### A. gRPC Service Definition and Implementation
+
+gRPC services are defined using Protobuf schemas to specify methods that can be called remotely.
+
+1. **Service Definition (Conceptual):** The Fabric ordering nodes expose a `ClusterNodeService` interface (or similar). This service includes streaming RPC methods like `Step`, which is used for continuous communication, carrying `ConsensusRequest` and `SubmitRequest` messages.
+2. **Server-Side (Ingress):** The `Consenter` object registers its `ClusterService` implementation with the main gRPC server using `ab.RegisterClusterNodeServiceServer(srv.Server(), consenter.ClusterService)`. When a remote node calls `Step`, the orderer's `ClusterService` receives the request.
+    - The `Comm` (Communication Manager) or `ClusterService` handler identifies the request type (e.g., consensus or submit) and sender ID.
+    - If it is a `SubmitRequest` (client transaction), the message is dispatched via `c.H.OnSubmit`.
+    - If it is a `ConsensusRequest` (inter-node message), it is dispatched via `c.H.OnConsensus`. The `Ingress` component (which implements `Handler` or `Dispatcher`) then takes the `ConsensusRequest`, unmarshals the nested consensus message (`bdls.Message`), and passes it to the specific chain's handler.
+
+### B. Client-Side (Egress) and RPC
+
+The client-side uses the `RPC` interface to perform remote calls.
+
+1. **The `RPC` Interface:** Production consensus modules require an `RPC` interface that defines how messages are sent, notably `SendConsensus(dest uint64, msg *ab.ConsensusRequest) error`.
+2. **Sending Messages:** The `Egress` component wraps the internal consensus message (`bdls.Message` or `protos.Message`) into a standardized `orderer.ConsensusRequest`. It then calls the underlying `RPC` implementation to transmit the message.
+3. **gRPC Stream Management:** The Fabric `RPC` implementation (`cluster.RPC`) manages streams (`cluster.Stream`). When `SendConsensus` is called, it either reuses an existing stream or calls `getOrCreateStream`.
+    - `getOrCreateStream` obtains a gRPC connection and uses `RemoteContext` to create a `Stream`.
+    - The `Stream` manages a buffer (`sendBuff`) and uses the Protobuf definition (`orderer.StepRequest`) to encapsulate the message for transmission over the gRPC network connection.
+
+### C. Authentication (Security over gRPC)
+
+In Fabric, gRPC communication relies on mutual TLS authentication for secure **point-to-point authenticated channels**.
+
+- The `AuthCommMgr` handles client-side connections.
+- When a stream is established, the client performs an `Auth()` handshake. This authentication request includes cryptographic signatures and checks the TLS session binding to verify the identity of the sending node.
+
+## 3. Go Concurrency: Managing RPC Streams and State
+
+Go's built-in concurrency model, based on **goroutines and channels**, is fundamental to how gRPC and consensus protocols operate efficiently in Fabric.
+
+### A. Goroutines and Asynchronous Tasks
+
+A **goroutine** is a lightweight, concurrently executing activity.
+
+- In the orderer, incoming gRPC streams (handled by `ClusterService.Step`) are typically processed by goroutines to avoid blocking the server.
+- Consensus tasks like proposing a block, handling messages, and processing client submissions are run in separate goroutines. For example, the BDLS `Chain.Start()` function executes `c.startConsensus` and `c.run()` concurrently using `go` routines.
+
+### B. Channels and Message Passing
+
+**Channels** are the communication mechanism used to synchronize and pass values between goroutines. The Go mantra is: "Do not communicate by sharing memory; instead, **share memory by communicating**".
+
+- **Synchronization (BDLS Example):** In BDLS, the `c.run()` function uses channels like `submitC` and `applyC` to control message flow and block writing. The `submitC` channel queues incoming transactions for ordering.
+- **Buffered Channels:** Channels can be buffered, allowing a limited number of elements to be stored before blocking occurs. Buffered channels decouple sending and receiving goroutines, enabling performance gains (e.g., returning the quickest response in `mirroredQuery` without waiting for slower ones, thereby avoiding a goroutine leak). The `cluster.Stream` uses a buffered channel (`sendBuff`) to queue outgoing gRPC requests.
+- **Unbuffered Channels:** An unbuffered channel guarantees synchronization between the sender and receiver—the send blocks until the receive happens.
+- **Unidirectional Channels:** Types like `chan<- string` (send-only) and `<-chan string` (receive-only) document intent and prevent misuse, enforced at compile time.
+
+### C. Safety and Mutual Exclusion
+
+While Go favors communication via channels, direct shared memory access requires explicit synchronization:
+
+- **Mutexes (`sync.Mutex`):** Used to protect shared variables, ensuring only one goroutine accesses the variable at a time. For instance, a cache implementation uses a mutex to guard the map access (`memo.mu.Lock()`/`memo.mu.Unlock()`).
+- **Read/Write Mutexes (`sync.RWMutex`):** Used when shared data is frequently read but rarely written, allowing multiple readers concurrently while writers must wait.
+- **Data Races:** Accessing shared variables from multiple goroutines without adequate synchronization leads to data races, which must be avoided for reliable concurrent programs.
+---
+
+The RPC (Remote Procedure Call) interface in Hyperledger Fabric's ordering service is crucial for coordinating consensus and communicating transaction requests among nodes. In both **etcdraft** (Crash Fault Tolerant or CFT consensus) and **SmartBFT** (Byzantine Fault Tolerant or BFT consensus), this communication is built upon **gRPC**, a high-performance, open-source universal RPC framework.
+
+The implementation details and the requirements imposed on the RPC layer differ significantly due to the fundamental difference in their fault tolerance models (CFT vs. BFT), particularly concerning trust, verification, and performance characteristics.
+
+## I. RPC Interface Implementation in etcdraft (Raft-OS)
+
+Hyperledger Fabric adopted Raft-OS as its default ordering service, based on a Go implementation of the Raft consensus algorithm from etcd.
+
+### A. Communication Mechanism
+
+1. **Transport Layer:** Raft-OS uses **gRPC** for communication between ordering service nodes (OSNs).
+2. **Request Types:** The communication layer utilizes a generalized mechanism to handle two primary types of messages: `ConsensusOperation` (internal Raft messages) and `SubmitOperation` (client transaction requests, typically forwarded to the leader).
+3. **RPC Layer Abstraction:** The `etcdraft` implementation leverages the general Fabric `cluster` communication infrastructure via an `RPC` interface.
+    - The `RPC` interface defines key methods like `SendConsensus(dest uint64, msg *orderer.ConsensusRequest)` and `SendSubmit(dest uint64, request *orderer.SubmitRequest, report func(error))`.
+    - The internal communication stream uses **Protocol Buffers** (Protobufs) for serialization, encapsulating both consensus and submit messages within a generic `StepRequest` when transmitting between cluster members.
+4. **Transaction Flow via RPC:**
+    - Clients typically submit transactions to a single ordering node (preferably the Raft leader).
+    - If a non-leader node receives a client transaction proposal (`SubmitRequest`), it identifies the current leader and forwards the request using `c.rpc.SendSubmit`.
+    - Raft nodes communicate internal consensus messages (like votes or log entries) using `SendConsensus`, where the payload is a marshaled Raft message.
+
+### B. Efficiency Focus (CFT Context)
+
+In Raft (a CFT protocol), the leader is assumed to be crash-fault tolerant but not malicious. This means followers **trust the leader's block proposal** during the ordering phase, simplifying the communication logic.
+
+A key performance feature of Raft is its ability to **pipeline** consent on blocks, meaning the leader can propose subsequent blocks before receiving full confirmation on the previous one. This parallelism significantly boosts throughput, especially in high-latency (WAN) environments.
+
+## II. RPC Interface Implementation in SmartBFT (BFT-OS)
+
+SmartBFT is Hyperledger Fabric’s BFT ordering service, based on the BFT-SMART protocol and written in Go. Its RPC implementation must handle Byzantine faults (arbitrary, malicious behavior), which introduces complexity absent in Raft.
+
+### A. Communication Mechanism
+
+1. **Core Components:** SmartBFT utilizes a specialized BFT consensus library that integrates deeply with Fabric's existing infrastructure. It also employs the standard Fabric `cluster` RPC components (`Egress` and `RPC`) to manage network communication.
+2. **Library API:** The library defines an interface for the application (the Fabric OSN) to manage communication. The `Egress` component handles sending BFT consensus messages (`SendConsensus`) and transactions (`SendTransaction`) to the cluster.
+3. **Client Submission:** Due to the risk of malicious ordering nodes (e.g., censorship), clients are required to **submit every transaction to all ordering nodes** (the entire quorum). This differs fundamentally from the typical Raft client flow, which targets just the leader.
+4. **BFT Messages and Signatures:** BFT protocols rely on cryptographic primitives to ensure safety against malicious nodes. Messages sent during the commit phase must be signed by a quorum of nodes ($Q = 2F+1$ committed signatures) to constitute a "decision" that is delivered to the application. The communication component is responsible for handling these cryptographic operations (signing outgoing messages and verifying incoming ones) via the `crypto` component.
+
+### B. BFT-Specific RPC Requirements (Trustless Context)
+
+The necessity to handle Byzantine faults dictates several constraints on the communication flow that are reflected in the API:
+
+1. **Mandatory Proposal Validation:** When a follower node receives a block proposal from the leader (via a `PRE-PREPARE` message), it cannot trust the leader. The follower must therefore **revalidate every transaction** within the proposed block against the Fabric application semantics during the consensus protocol itself. This requires adding APIs for transaction verification inside the RPC flow.
+2. **Quorum Signatures:** The block decision delivered to the committer peer must include the signatures of a quorum of ordering nodes ($Q=2F+1$ signatures). This means the RPC structure must accommodate collecting these signatures as part of the consensus mechanism, often during the commit phase.
+3. **Dynamic Configuration:** The library supports dynamic reconfiguration, where the consensus configuration can be inferred and updated after each commit via the `Deliver` or `Sync` calls returning a `RECONFIG` object.
+
+## III. Key Differences Between SmartBFT and etcdraft RPC Implementations
+
+The differences stem primarily from the inherent security and performance trade-offs between a CFT protocol (Raft) and a BFT protocol (SmartBFT).
+
+|Feature|etcdraft (CFT)|SmartBFT (BFT)|
+|:--|:--|:--|
+|**Trust Model and Validation**|The RPC process implicitly trusts the leader's proposal once established, relying on the leader to batch transactions correctly. Validation complexity is low during consensus.|Followers explicitly distrust the leader, requiring them to **revalidate every transaction** in the proposed block as part of the consensus protocol flow.|
+|**Client Submission**|Clients submit transactions to a single node (leader or follower for forwarding).|Clients must submit to a quorum of orderers to prevent censorship attacks by malicious leaders.|
+|**Pipelining and Latency**|**Supports pipelining** of consensus messages, allowing the leader to propose future blocks before confirmation of the current one. This is key to high throughput, especially in WAN environments.|Historically, SmartBFT (based on BFT-SMART) does not allow for a transaction pipeline, as there is only a single proposed transaction by a leader at any time. This design simplifies the view change sub-protocol but **reduces maximum performance** and causes throughput to decrease significantly in WAN setups.|
+|**Computational Overhead**|Lower computational burden, as it primarily relies on crash-fault guarantees and standard network communication.|High computational overhead due to the mandatory use of **cryptographic operations** (digital signatures) for message verification (e.g., verifying a quorum of commits).|
+|**Message Complexity**|Raft-based consensus typically maintains efficient (linear) message complexity $O(N)$, where $N$ is the number of nodes.|SmartBFT (which belongs to the PBFT family) typically suffers from **quadratic message complexity** $O(N^2)$ during core consensus phases (Prepare and Commit) because every node must communicate with every other node. For example, 100 ordering nodes would require over 40,000 messages for a single block decision in the PBFT protocol family.|
+|**Synchronization Protocol**|Synchronization focuses on log replication and ensuring all nodes have the same ordered stream of blocks.|SmartBFT requires a **BFT-compliant replication protocol** for synchronization (`Sync()`/`Resync`), where blocks pulled from other OSNs must be validated to ensure they are properly signed by a quorum of OSNs.|
+
+In summary, while both utilize gRPC as the underlying transport mechanism, **etcdraft** prioritizes efficiency and throughput by leveraging a highly optimized CFT protocol that supports pipelining and minimizes cryptographic overhead. In contrast, **SmartBFT** introduces necessary complexity into the RPC implementation to enforce Byzantine fault tolerance, requiring explicit verification mechanisms, mandatory client broadcast, and quorum-based signing schemes, resulting in a higher message complexity and lower throughput capacity compared to Raft.
+
+
+----
+
+The goal is to transition BDLS's internal communication mechanism from its current custom TCP/agent implementation to the standardized **Fabric Cluster Service**, which exclusively uses the **gRPC** transport layer for inter-orderer communication.
+
+## I. Issues with Current Core Consensus Logic in BDLS
+
+The primary issues that must be addressed before refactoring the BDLS orderer code to fully integrate Fabric's cluster service revolve around the **communication egress layer**.
+
+The existing BDLS implementation, while integrated into the Fabric structure, relies on a distinct, low-level network layer (`bdls/agent-tcp`) for message transmission, bypassing Fabric's standard RPC framework:
+
+### 1. Custom TCP-Based Transport Layer
+
+The BDLS implementation uses an internal `agent-tcp` package, specifically relying on the `agent.TCPAgent` structure.
+
+- **Internal Networking:** The `Chain` object in BDLS explicitly holds a reference to a `transportLayer *agent.TCPAgent`.
+- **Direct Message Flow:** The `startConsensus` function initializes the core `bdls.Consensus` object and then uses the `transportLayer` to propose data via `c.transportLayer.Propose(data)`. Similarly, incoming messages are handled by the agent via `agent.consensus.ReceiveMessage`.
+- **Bypassed Fabric Cluster RPC:** This custom implementation means the BDLS consensus messages are being sent directly over TCP connections managed by the `TCPAgent`, rather than flowing through the generic Fabric `cluster.RPC` interface, which is built on gRPC and provides authentication, stream management, and standardized logging.
+
+### 2. Disconnect from Fabric’s Standard Communicator Interface
+
+While the BDLS `Consenter` structure receives and initializes the standard Fabric communicator (`c.Comm *cluster.AuthCommMgr`) and passes a `comm cluster.Communicator` to `NewChain`, the internal BDLS consensus process never utilizes this communication object for its essential consensus steps (`RoundChange`, `Lock`, `Commit`).
+
+### 3. Missing Standardized Egress Logic
+
+Protocols like SmartBFT and etcdraft rely on intermediate components to translate their core protocol messages into the Fabric `orderer.ConsensusRequest` Protobuf structure required by the cluster service.
+
+- **Raft Disseminator:** Raft uses a `Disseminator` to piggyback cluster metadata onto the outgoing `ConsensusRequest`.
+- **SmartBFT Egress:** SmartBFT defines a dedicated `Egress` object which receives the SmartBFT native message (`*protos.Message`) and wraps it into a Fabric `ConsensusRequest` via the `bftMsgToClusterMsg` function before calling `e.RPC.SendConsensus`.
+
+The BDLS implementation currently lacks this explicit Fabric Egress abstraction; its messages are sent out directly via the custom `TCPAgent`.
+
+## II. Refactoring BDLS for Integrating Fabric's Cluster Service (gRPC Transport)
+
+To enable the gRPC transport layer via Fabric’s cluster service, the BDLS orderer code must be refactored to replace its direct TCP handling with the standard `cluster.Communicator` interface, following the architecture used by other Fabric cluster protocols.
+
+The general approach involves three key steps: defining the message wrapping logic, implementing the standard Egress/RPC component, and configuring the BDLS consensus core to use this new component for all outgoing communication.
+
+### Step 1: Implement the BDLS Egress Component
+
+The current BDLS protocol messages must be encapsulated within Fabric’s standard `ConsensusRequest` (which travels over the underlying gRPC stream managed by the cluster service).
+
+1. **Define the Egress Structure:** Create a dedicated BDLS `Egress` structure (as is partially outlined in the BDLS sources) that holds a reference to the Fabric `RPC` interface (`cluster.RPC`).
+2. **Implement `SendConsensus` Mapping:** Implement the required communication methods (like `SendConsensus` or `SendTransaction`) using the external `RPC` object.
+    - This function receives the BDLS core message (`*bdls.Message`).
+    - It uses a conversion function (analogous to SmartBFT's `bftMsgToClusterMsg`) to marshal the BDLS message payload into the `orderer.ConsensusRequest` object.
+    - It then calls the standard Fabric cluster interface method: `e.RPC.SendConsensus(targetID, clusterMsg)`.
+
+### Step 2: Configure the BDLS Consensus Core
+
+The core BDLS logic must be decoupled from the internal `agent-tcp` layer and instructed to use the newly created Fabric-compliant Egress component for its message passing operations (`broadcast`, `sendTo`).
+
+1. **Modify `NewChain` Initialization:** In the `NewChain` function, the specialized BDLS core consensus object (`bdls.Consensus`) is created. Instead of passing it configuration that leads to the initialization of the internal TCP agent, the core object must be configured to use the Fabric cluster wrapper.
+2. **Inject Fabric Communicator:** When initializing the BDLS core consensus object, ensure that the communication mechanism provided matches the necessary interface expected by the BDLS core library (`PeerInterface`). This typically involves wrapping the Fabric `cluster.Communicator` (`c.Comm` received by the chain) within the BDLS Egress structure (Step 1) and passing this structure to the BDLS core constructor.
+3. **Update `Chain.Start()` Logic:** The `Chain.Start()` function initiates consensus by calling `go c.startConsensus(c.config)`. This routine must be updated to remove all references to the `c.transportLayer` and rely purely on message dispatching through the Fabric Egress layer.
+
+### Step 3: Align Request Submission and Delivery
+
+While the current BDLS implementation handles client transaction requests using channels (`c.submitC`) and processes blocks via `c.applyC`, ensuring correctness requires verification that the flow aligns with the block cutting model used by Fabric cluster protocols (Model 2: Messages are cut into blocks, the blocks are ordered, then the blocks are committed).
+
+1. **Block Creator Alignment:** In the BDLS `startConsensus` function, the `blockCreator` uses the hash and number of the last committed block (`c.lastBlock`) and cuts the batch to create the next block `b`. This resulting block `b` is then proposed to the consensus system (`c.propose(ch, bc, batches...)`). This logic, which uses `c.support.BlockCutter().Ordered(...)`, is already consistent with the ordering model used by Raft.
+2. **Message Reception (Ingress):** The BDLS ingress logic, already present in the sources, reads incoming Fabric `ConsensusRequest` and handles unmarshaling the payload back into the core BDLS `Message` (`*protos.Message`) before invoking the chain's `HandleMessage`. This mechanism is ready, provided the messages are now arriving via the standard Fabric cluster stream.
+
+By successfully replacing the `agent-tcp` logic with a layer built upon the Fabric `cluster.RPC` and `Communicator` interfaces, BDLS can leverage the gRPC transport layer, benefiting from Fabric's existing connection management, authentication, and monitoring. This also means removing the private TCP authentication protocol described in the BDLS agent sources (e.g., `handleKeyAuthInit`, `handleKeyAuthChallenge`), as gRPC handles authentication and TLS at the transport layer, managed by the `AuthCommMgr`.
+
+----
+
+This is a highly insightful and accurate assessment of the challenges involved in porting the BDLS consensus Proof of Concept (POC) into the structured environment of Hyperledger Fabric’s standard cluster service.
+
+You are correct: the **`PeerInterface`** within the BDLS core library, and its reliance on the custom **`agent-tcp`** transport implementation in the current Fabric wrapper, is the primary architectural bottleneck that fundamentally prevents leveraging the standardized Fabric Cluster Service (gRPC).
+
+To successfully integrate BDLS using the standard Fabric RPC/gRPC transport, the BDLS core consensus library must undergo significant internal refactoring to become transport-agnostic and align with how Fabric manages remote communication.
+
+Here is a detailed breakdown of the necessary changes, why they are required, and how they should be implemented in the BDLS core library.
+
+---
+
+## I. Why the Current `PeerInterface` is the Bottleneck
+
+The fundamental issue is that the current BDLS architecture conflates the **abstract consensus mechanism** with the **concrete network transport layer**.
+
+### 1. The Conflation of Roles
+
+The BDLS consensus core object (`bdls.Consensus`) currently interacts with an array of peers defined by the `PeerInterface`. This interface demands methods necessary for low-level TCP/IP networking, specifically:
+
+- **Low-Level Sending:** The `PeerInterface` requires a `Send([]byte) error` method.
+- **Address Management:** The interface implies the peer object must hold network information, as indicated by the dependency on `RemoteAddr() net.Addr`.
+
+In the current BDLS Fabric POC, these requirements force the creation of the custom `agent.TCPAgent` and `TCPPeer` structures solely to bridge the Fabric environment to the core consensus library. This custom agent then executes its own TCP connection loops, authentication protocols (e.g., `handleKeyAuthInit`, `handleKeyAuthChallenge`), and data marshaling—all of which bypass and duplicate the robust functionality provided by the existing Fabric `cluster.AuthCommMgr`.
+
+### 2. Conflict with Fabric's Cluster Service (gRPC)
+
+Fabric's standard cluster service expects a consensus protocol to integrate at a high level via its **`cluster.Communicator`** interface. Communication functions are implemented via the `cluster.RPC` interface, which defines methods like `SendConsensus(dest uint64, msg *orderer.ConsensusRequest)`.
+
+To function correctly within Fabric:
+
+1. The consensus implementation (the Fabric BDLS wrapper) should provide an **Egress layer** (`bdls.Egress`) that translates native BDLS consensus messages into the required Fabric message format (`orderer.ConsensusRequest`).
+2. This Egress layer relies on the Fabric `cluster.RPC` to deliver the message to a target node identified by its Fabric ID (`uint64`).
+3. The core consensus library should **not** care _how_ the bytes are sent, only that they are delivered to the correct destination ID.
+
+By requiring `PeerInterface`, the BDLS core library currently demands its host environment (the Fabric orderer wrapper) implement direct peer management, making it impossible to inject the standard Fabric gRPC `cluster.RPC` directly into the BDLS core in a clean, idiomatic way.
+
+## II. Required Changes in the BDLS Core Consensus Library
+
+The goal of refactoring the BDLS core library (`github.com/BDLS-bft/bdls`) is to replace the tight coupling created by `PeerInterface` with a flexible, ID-based message transmission abstraction.
+
+### A. The "What": Define a Transport-Agnostic Interface
+
+We must redefine how the core library broadcasts and sends messages to participants.
+
+1. **Eliminate `PeerInterface`:** Remove the dependency on `bdls.PeerInterface` (which couples the core logic to the concept of a network connection endpoint).
+2. **Define a `Transmitter` Interface:** Introduce a new, minimal interface focused purely on transmitting raw consensus data, indexed by the target participant's ID (`Identity` is currently defined as derived from public key coordinate but maps logically to a unique `uint64` ID within the Fabric context).
+
+|Current BDLS Core Interface (Coupled)|Proposed BDLS Core Interface (Decoupled)|
+|:--|:--|
+|`PeerInterface` (requires `Send(bts []byte) error` and `RemoteAddr()`)|`Transmitter` (requires `SendTo(target Identity, rawMessage []byte) error`)|
+
+### B. The "How": Implementation Steps within BDLS Core
+
+These changes allow the Fabric wrapper layer to cleanly implement the `Transmitter` interface using its own `bdls.Egress` component, which in turn calls the Fabric `cluster.RPC`.
+
+#### 1. Modify `bdls.Consensus` Structure
+
+The `Consensus` object currently holds an array of `PeerInterface`.
+
+- Replace `peers []PeerInterface` with a single field representing the new communication function, for instance:
+    
+    ```
+    type Consensus struct {
+        // ... existing fields ...
+        comm Transmitter // The new, simplified interface
+        // ... existing fields ...
+    }
+    ```
+    
+
+#### 2. Update Message Dispatch Logic
+
+The core BDLS protocol handles sending messages via `broadcast` and `sendTo` functions. These functions must be updated to use the new `Transmitter` interface and the participant identities (`Identity` type).
+
+- **Refactor `broadcast(*Message)`:** This function iterates over all participant identities (`c.participants`) and calls `c.comm.SendTo(participantID, marshaledMessage)`.
+- **Refactor `sendTo(*Message, leader Identity)`:** This function uses `c.comm.SendTo(leader, marshaledMessage)`.
+
+Crucially, this moves the responsibility of managing peer lists and connection status **out** of the core consensus engine and **into** the Fabric `cluster` management layer.
+
+#### 3. Eliminate Connection Management Dependencies
+
+Remove all remaining dependencies on low-level network concepts within the BDLS core library, specifically:
+
+- **Remove `Join` and `Leave`:** The `Join` and `Leave` methods on `bdls.Consensus` are currently used to manage the `peers` array. These should be removed, as membership changes are strictly the responsibility of the Fabric `cluster.AuthCommMgr` configured by the channel’s configuration block. The Fabric wrapper will configure the `Transmitter` upon initialization and reconfiguration.
+- **Remove `net` Dependency:** Erase all uses of `net.Addr` (or similar network types) inside the core consensus logic.
+
+### C. The Result: Aligning BDLS with Fabric Architecture
+
+This internal change in the BDLS core library forces the Fabric BDLS wrapper to use a structure identical to SmartBFT's egress layer:
+
+1. **BDLS Egress Implementation:** The Fabric BDLS wrapper will implement the `Transmitter` interface required by the BDLS core. The existing `bdls.Egress` component already contains the necessary Fabric `cluster.RPC` interface and Protobuf conversion logic (`bftMsgToClusterMsg`).
+2. **Bridging the gap:** The `SendTo` implementation inside the Fabric wrapper will:
+    - Receive the target ID (`uint64`) and the raw BDLS message (`[]byte`).
+    - Unmarshal the raw bytes into a BDLS message structure (`*bdls.Message`).
+    - Wrap this message into a Fabric `orderer.ConsensusRequest`.
+    - Call the standard Fabric cluster RPC: `e.RPC.SendConsensus(targetID, consensusRequest)`.
+
+This ensures BDLS communication utilizes **gRPC streams**, **Fabric authentication**, and **standardized message formats** established by the `cluster` package, eliminating the need for the redundant, custom `agent-tcp` implementation.
+
+The architectural change of abstracting the communicator interface is key to enabling pluggability, which is a core design philosophy of Hyperledger Fabric. This process mirrors the architectural pattern successfully used by the SmartBFT developers when creating their Go library wrapper for Fabric.
+
+
+----
+
+Your desire to look **deeply into the core BDLS consensus library (`consensus.go`)** and restructure it for better separation of concerns is critical for a robust integration with Hyperledger Fabric's Cluster Service (gRPC transport). The current implementation, being a Proof of Concept (POC), exhibits tight coupling between its core logic and network management, which is incompatible with Fabric's modular architecture.
+
+The core issue lies in the design of internal communication within the BDLS library (`github.com/BDLS-bft/bdls`), specifically how it abstracts (or fails to abstract) the sending and receiving of messages.
+
+## I. Deep Issues in the Core BDLS Consensus Library
+
+The core BDLS consensus object (`bdls.Consensus`) currently violates the principle of separation of concerns by containing direct knowledge and functionality related to network peers and low-level communication timeouts.
+
+### 1. Hard Coupling to the Peer Interface (`PeerInterface`)
+
+The most significant bottleneck is the `PeerInterface` definition, which mandates low-level network operations.
+
+- **Network-Specific Abstraction:** The `bdls.Consensus` struct holds a slice of peers: `peers []PeerInterface`.
+- **Direct Send Function:** The BDLS core relies on `PeerInterface` to expose a `Send([]byte) error` method for message transmission. This forces the consumer (the Fabric orderer wrapper) to manage the actual TCP connection and byte serialization.
+- **Address Dependency:** The `PeerInterface` also requires `RemoteAddr() net.Addr` and includes `Join(p PeerInterface)` and `Leave(addr net.Addr)` methods which directly manage network connections based on addresses.
+
+This means the consensus engine dictates how messages are sent (via a peer object capable of sending raw bytes), rather than focusing purely on _what_ data needs to be delivered and _to whom_ (identified by a logical ID). This design necessitates the creation of the custom `agent.TCPAgent` and related TCP logic in the Fabric layer (`orderer/consensus/bdls/agent-tcp`) to bypass Fabric's native gRPC/cluster infrastructure.
+
+### 2. Conflation of I/O and Core Logic
+
+The `bdls.Consensus` object handles the core protocol logic, but it also contains internal routines for managing how messages are routed, including loopbacks and propagation.
+
+- **Custom Dispatching Logic:** Functions like `broadcast()` and `sendTo()` serialize the message, sign it, and then explicitly iterate over the `c.peers` list to invoke `peer.Send(out)`. This I/O logic should ideally reside entirely outside the core consensus state machine.
+- **Loopback Management:** The core library uses an internal slice `loopback [][]byte` to queue messages addressed to itself, which are processed via `defer` statements in `ReceiveMessage` and `SubmitRequest`. While designed to maintain determinism and avoid side effects, this is a transport concern and should be handled by the external communication framework (which, in Fabric, uses goroutines and channels for communication, including loopbacks for local delivery).
+
+### 3. Mixing Protocol Timing and Environment Parameters
+
+The core `Consensus` structure holds explicit timing variables (`rcTimeout`, `lockTimeout`, `commitTimeout`, `lockReleaseTimeout`) and calculates durations based on a generic `latency` parameter.
+
+- While the BDLS library is commendably designed to be deterministic by taking `now time.Time` as a parameter to its main functions (`ReceiveMessage`, `Update`), the tight integration of these specific timeout calculations within the consensus object itself limits flexibility in how the application (Fabric) wishes to manage its clock and error handling.
+
+## II. Redesigning the Architecture for Separation of Concerns
+
+To enable seamless integration with Fabric's Cluster Service (gRPC), the BDLS core library must adopt the pattern established by the SmartBFT library, focusing on pure, transport-agnostic computation.
+
+### A. Principle 1: Separate Communication (I/O) from Computation (Consensus)
+
+The goal is to ensure the `bdls.Consensus` object only computes the next state and decides which messages need to be sent out, leaving the responsibility of serialization, signing, and transport to the external application (Fabric).
+
+|Current (Coupled) BDLS Core Logic|Proposed Refactoring (Decoupled)|
+|:--|:--|
+|`type Consensus` stores `peers []PeerInterface` and cryptographic keys.|**Remove** all network interfaces and keys.|
+|`broadcast(m *Message)` signs the message, marshals it, and calls `peer.Send(bts)`.|**Introduce a `Transmitter` Interface** (like the new suggestion in our previous chat).|
+|`Consensus.receiveMessage(bts []byte)` handles unmarshaling/verification.|The application layer (Fabric BDLS wrapper) should handle verification, signing, and marshalling/unmarshaling of messages _before_ calling the consensus core.|
+
+### B. The "What & How": Implementing a Clean `Transmitter` Interface
+
+The core library needs a callback mechanism to output messages without knowing _how_ they are transported.
+
+1. **Define the `Transmitter` Interface (in the core BDLS library):** This interface should only expose methods needed to dispatch messages using the logical ID of the recipient.
+    
+    ```
+    type Transmitter interface {
+        // SendTo delivers the marshaled consensus message (ready for network dispatch)
+        // to the specified target. Identity should map to the Fabric uint64 ID.
+        SendTo(target Identity, marshaledMessage []byte)
+        // Broadcast delivers the marshaled message to all participants (excluding self).
+        Broadcast(marshaledMessage []byte)
+    }
+    ```
+    
+2. **Inject `Transmitter` into `bdls.Consensus`:** Replace `peers []PeerInterface` with a `Transmitter` instance provided during `NewConsensus` initialization.
+    
+3. **Refactor `broadcast` and `sendTo` Internally:** The existing internal methods like `c.broadcast` and `c.sendTo` must be modified to use the injected `Transmitter`.
+    
+    - **Crucially, the `bdls.Consensus` library should no longer handle raw cryptographic signing and message marshaling for egress.** It should output a standardized, ready-to-send structure, or delegate the marshaling entirely to the consumer. Currently, `broadcast()` calls `m.Sign(m, c.privateKey)` and marshals to `SignedProto` internally before calling `peer.Send`. This logic must be externalized.
+    - **External Cryptography:** BDLS already provides external `SignerSerializer` and `crypto` components in the Fabric wrapper structure (`Consenter`). The consensus core should simply pass the message content (`bdls.Message`) and its identity ID to the application layer via the `Transmitter` interface, which handles the secure serialization (signing and packaging into `ab.ConsensusRequest`).
+
+### C. Principle 2: Adopt the Hook Pattern for Flexibility
+
+The successful SmartBFT integration relies heavily on interfaces (hooks) that allow the Fabric application to inject necessary logic and utilize Fabric's existing resources (like transaction validation, signing, and logging) during the consensus process.
+
+The BDLS core already has a configuration struct (`bdls.Config`) with functions like `StateCompare` and `StateValidate`. We must extend this concept to communication and protocol sequencing.
+
+1. **Externalize Egress Callback (Replacing Direct `SendTo`):** Currently, BDLS uses `c.messageOutCallback(m *Message, signed *SignedProto)`. This should be formalized into the `Transmitter` interface used by the outer wrapper to perform the network send via gRPC.
+    
+2. **Rethink Client Submission Flow:** The SmartBFT core mandates application involvement for block construction (`Assemble`) and proposal verification (`VerifyProposal`) because BFT protocols cannot trust the leader.
+    
+    - BDLS currently relies on `c.consensus.SubmitRequest(req, time.Now())` triggered by `HandleRequest` in the Fabric wrapper.
+    - To mirror BFT requirements, the BDLS core library should expose an explicit interface (like SmartBFT's `Assemble(metadata, reqs) Proposal` and `VerifyProposal(Proposal) error`) to the Fabric wrapper. This ensures the Fabric application can handle mandatory transaction revalidation (`VerifyRequest`) _before_ the BDLS follower accepts a leader's proposal, fulfilling the BFT security requirement overlooked in previous BFT integration attempts.
+
+### D. Concurrency and Determinism Management
+
+The core BDLS consensus library is deliberately designed to be deterministic and **not thread-safe**. It mandates that users handle their own synchronization (`sync.Mutex` in `Chain` struct) and feed time ticks via `Update(now time.Time)`.
+
+When integrating with Fabric's gRPC Cluster Service, which is asynchronous and multithreaded (using goroutines), the **Fabric BDLS wrapper (`Chain` object)** must remain the strict gatekeeper using Go concurrency primitives (channels and mutexes):
+
+1. **Remove Internal Loopback:** Once the communication layer (the `Transmitter` implemented in the Fabric wrapper) is responsible for routing messages, it should handle self-delivery via Fabric channels, allowing the core BDLS library to remove its non-deterministic `loopback` management.
+2. **Centralized State Machine Access:** Ensure that the wrapper's main loop (`Chain.run()`) is the _only_ entry point that calls mutating functions on the `bdls.Consensus` object (i.e., `ReceiveMessage`, `Update`, `SubmitRequest`), protecting it from concurrent access, as mandated by the library's design. This aligns with best practices for managing state in concurrent Go systems.
+
+By implementing these changes—primarily migrating all network I/O, signing, unmarshaling, and peer management **out** of the `bdls.Consensus` structure and **into** a new Fabric-compliant `Egress`/`Transmitter` layer—the BDLS core becomes a clean, reusable, transport-agnostic computation library ready to interface cleanly with the Fabric Cluster Service.
+
+
+----
+
+This analysis draws upon the structure of the BDLS core library (`consensus.go`), the Fabric BDLS wrapper implementation (`chain.go`, `agent-tcp`), and the successful integration architecture of SmartBFT and the foundational Fabric Cluster Service (gRPC).
+
+The core issues prevent a smooth gRPC integration because the BDLS library **conflates the consensus algorithm logic with the concrete networking transport and security layers**, violating the crucial **separation of concerns** necessary for pluggability in Fabric.
+
+Here is a deep reasoning why these architectural choices in the BDLS core library create insurmountable barriers for a smooth integration with Fabric's gRPC Cluster Service:
+
+---
+
+## 1. Conflict in Transport Abstraction: Raw Peer Interfaces vs. Logical gRPC Channels
+
+The fundamental incompatibility stems from the difference between how BDLS views communication partners and how Fabric's Cluster Service manages them.
+
+### Why BDLS Blocks gRPC Integration:
+
+1. **Peer Interface Dependency:** The BDLS core consensus structure (`bdls.Consensus`) is hard-coded to communicate using a collection of `peers []PeerInterface`. The `PeerInterface` mandates low-level operations inherent to network transport, such as providing a raw destination address (`RemoteAddr() net.Addr`) and directly transmitting serialized data via `Send([]byte) error`.
+2. **Forced Custom Transport:** This requirement compels the Fabric BDLS implementation to create and manage its own **custom TCP agent** (`agent.TCPAgent`) in the `agent-tcp` package, complete with separate Goroutines for sending and receiving (`sendLoop()`, `readLoop()`). This agent then handles connection management, message framing (using `MessageLength` headers), and authentication entirely outside of Fabric's standard mechanism.
+3. **Bypass of Cluster Services:** The standard Fabric pattern, exemplified by SmartBFT, requires the consensus component to interact with the high-level `cluster.RPC` interface (via an `Egress` wrapper). This `RPC` layer uses abstract node IDs (`uint64`) and relies on the underlying `cluster.AuthCommMgr` to handle connection pooling, routing, and TLS security via gRPC.
+4. **Integration Impossibility:** The BDLS core cannot accept a `cluster.RPC` object (which expects a destination ID and a fully formatted Fabric Protobuf message) because it demands a `PeerInterface` (which expects a low-level network object capable of sending raw bytes to an address). Injecting the high-level Fabric `RPC` object directly into the tightly coupled BDLS internal `consensus.peers` field is architecturally unsound and functionally impossible, requiring the clumsy `agent-tcp` layer as an immediate workaround.
+
+## 2. Redundancy and Conflict in Authentication and Security
+
+Smooth integration requires utilizing Fabric's existing, robust security primitives. The current BDLS structure forces the creation of a redundant and potentially conflicting security model.
+
+### Why BDLS Blocks gRPC Security Integration:
+
+1. **Custom Key Authentication:** The BDLS `agent-tcp` implements a specific, custom public key authentication protocol involving multiple commands like `KEY_AUTH_INIT`, `KEY_AUTH_CHALLENGE`, and `KEY_AUTH_CHALLENGE_REPLY`. This mechanism uses ECDH key derivation (`ECDH`) and HMAC calculations for ephemeral key exchange.
+2. **Fabric Standard Security:** Fabric's cluster communication relies on **mutual TLS (mTLS)** for authenticated communication over gRPC. The `cluster.AuthCommMgr` handles connection establishment and certificate verification. Furthermore, to secure the consensus session itself, Fabric uses TLS session binding and digital signatures (using Fabric's identity framework—the signer serializer) to ensure messages are legitimate and non-replayable.
+3. **Architectural Overhead:** If the BDLS core were to maintain its `PeerInterface` dependency, the resulting system would require **two separate, running network and security stacks** within the orderer: the custom BDLS TCP agent with its homegrown authentication, and the standard Fabric `Comm` manager handling gRPC/mTLS. This massive redundancy increases computational overhead (BDLS already requires high CPU for BFT cryptographic operations) and makes deployment, monitoring, and maintenance significantly harder.
+
+## 3. Mixing Protocol Logic with I/O and Concurrency
+
+The BDLS library's internal design choices related to message processing and state management directly clash with Fabric's recommended concurrency patterns (Go routines and channels).
+
+### Why BDLS Blocks Smooth Concurrency Integration:
+
+1. **Non-Thread-Safe Core Logic:** The BDLS `Consensus` object explicitly states it "has no internal clocking or IO, and no parallel processing" and is **"not thread-safe"**. It requires the external application (the Fabric wrapper) to handle all synchronization via `sync.Mutex`.
+2. **Internal I/O Side Effects (Loopback Queue):** The functions responsible for processing incoming messages (`ReceiveMessage`, `SubmitRequest`) in `bdls.Consensus` contain `defer` blocks that manage an internal queue called `c.loopback [][]byte`. This mechanism queues messages addressed to the node itself and processes them recursively to "avoid side effects" while maintaining deterministic execution. This internal management of I/O (handling self-broadcast/loopback) is strictly a concern of the external communication layer in Fabric (which uses Go channels for clean message passing between goroutines).
+3. **Lack of Egress Separation:** The core BDLS library manages the serialization, signing, and dispatching of messages _within_ its consensus functions, rather than simply instructing the application layer what to send and to whom. This means:
+    - The BDLS logic performs the marshaling of `bdls.Message`.
+    - It then iterates over its internally managed `c.peers` list to invoke `peer.Send()`.
+    - The core **should** ideally output a message and an ID through a clean interface (`Transmitter`), but instead, it encapsulates the I/O itself.
+
+This lack of clean separation means the Fabric wrapper layer cannot easily intercept the message output, wrap it in the required `ab.ConsensusRequest`, and dispatch it asynchronously via the gRPC network managed by `cluster.RPC`. This architectural blockage mirrors the fundamental drawbacks encountered by the original BFT-SMART integration attempt in 2018, which was ultimately rejected because it used an external monolithic BFT cluster, failed to integrate cleanly, and missed opportunities for necessary optimizations.
+
+By requiring the application layer to implement the low-level `PeerInterface` (which manages bytes, addresses, and connections), the BDLS core library essentially demands that the Fabric orderer abandon its high-level gRPC transport abstraction and build a custom, redundant network stack just to satisfy the consensus engine's I/O dependencies. This is the definition of a bottleneck that prohibits smooth integration.
+
+
+----
+The **Cluster Service** in Hyperledger Fabric is the essential architectural framework that manages inter-node communication, security, and membership within the ordering service cluster, enabling consensus protocols like etcdraft and SmartBFT to operate efficiently and securely.
+
+It is the standard, gRPC-based transport layer that isolates the core consensus logic (the state machine) from the complexities of networking and connectivity.
+
+## I. What is the Fabric Cluster Service?
+
+The Cluster Service defines the communication mechanism used by all ordering service nodes (OSNs) within a channel's consenter set to exchange internal consensus messages and client transaction requests.
+
+### A. Core Components and Technology
+
+1. **Transport Layer (gRPC):** The Cluster Service exclusively uses **gRPC** (a high-performance, open-source universal RPC framework) for communication between nodes.
+2. **Message Types:** The service handles two primary operation types, differentiated in the `cluster.RPC` component:
+    - **ConsensusOperation:** Used for exchanging internal consensus messages (e.g., Raft `StepRequest` or BFT `PRE-PREPARE`/`COMMIT` messages).
+    - **SubmitOperation:** Used for forwarding client transaction submissions (`SubmitRequest`) to the appropriate node, typically the leader.
+3. **Security and Authentication:** Communication is secured using **mutual TLS (mTLS)** for authenticated channels. The authentication manager, **`AuthCommMgr`** (or `Comm`), manages client-side connections and streams established with the Cluster gRPC server. This manager handles security primitives like TLS session binding and digital signatures during message dispatching.
+4. **RPC Interface:** The core component that enables consensus protocols to send data is the **`cluster.RPC`** structure, which abstracts the stream implementation. It exposes methods like `SendConsensus` and `SendSubmit`.
+
+### B. Functions of the Cluster Service
+
+The cluster service performs several crucial functions to maintain the ordering network:
+
+- **Ingress Handling:** The server-side implementation (`ClusterService` or `Service`) receives incoming gRPC streams and dispatches the requests (Submit or Consensus) to the correct channel and the appropriate consensus component handler (`RequestHandler` or `Dispatcher`).
+- **Egress Management:** It manages streams (`cluster.Stream`) for sending messages to remote members, handling buffering and dropping messages if necessary (especially for high-volume consensus requests).
+- **Topology Management:** The `cluster.Communicator` interface (`AuthCommMgr` or `Comm`) handles dynamic membership changes (`Configure`) by connecting to all necessary members and disconnecting from removed ones, based on configuration block updates.
+
+## II. Cluster Service and etcdraft (CFT)
+
+The etcdraft ordering service (Raft-OS) uses the Cluster Service to manage all inter-node communication, relying on its crash fault tolerance (CFT) model which allows for simple, fast message exchange.
+
+### A. Encapsulation and Message Flow
+
+1. **Raft Core Decoupling:** The underlying Raft library from etcd is agnostic to networking and operates using only **logical Node IDs (`uint64`)**.
+2. **Raft Message Wrapping:** When the Raft core determines a message needs to be sent (`rd.Messages`), the Fabric wrapper translates the `raftpb.Message` into a Fabric cluster message. The Raft message is marshaled into a byte payload.
+3. **Encapsulation:** The marshaled Raft message payload is encapsulated within the `orderer.ConsensusRequest` structure.
+4. **Sending via RPC:** This `ConsensusRequest` is sent via the **`cluster.RPC.SendConsensus(destination, msg)`** call, where `destination` is the target Raft ID.
+5. **Metadata Piggybacking:** Raft uses a `Disseminator` component to wrap the base `RPC` and piggyback **cluster metadata** (like the list of active nodes) onto the outgoing `ConsensusRequest`.
+
+### B. Client Submission Flow
+
+In Raft-OS, clients typically submit transactions to a single ordering node.
+
+- If the receiving node is not the Raft leader, it encapsulates the client message into an `orderer.SubmitRequest` and forwards it to the detected leader using **`rpc.SendSubmit`**.
+
+## III. Cluster Service and SmartBFT (BFT)
+
+The SmartBFT ordering service (BFT-OS) is designed to be deeply integrated into the Fabric OSN process using the Cluster Service, but its BFT requirements impose additional constraints and architectural complexity.
+
+### A. Encapsulation and Egress Logic
+
+1. **BFT Core Decoupling:** The SmartBFT consensus library operates using logical node IDs and is designed with an explicit API to delegate communication to the application (Fabric).
+2. **The `Egress` Component:** SmartBFT utilizes an **`Egress`** structure (`smartbft/egress.go`) as the specific component that implements the communication interface for the core BFT library. This component holds the reference to the Fabric `cluster.RPC` interface.
+3. **Encapsulation:** When the core BFT engine outputs a message (`*protos.Message`), the `Egress.SendConsensus` method is called. This method executes **`bftMsgToClusterMsg`** to marshal the BFT message payload and encapsulate it into a Fabric `orderer.ConsensusRequest`.
+4. **Sending via RPC:** The `Egress` component then uses the standard Fabric Cluster RPC to dispatch the message via gRPC streams: `e.RPC.SendConsensus(targetID, clusterMsg)`.
+
+### B. BFT-Specific Encapsulation Requirements
+
+Because SmartBFT is Byzantine Fault Tolerant, its integration requires specialized handling during block creation and delivery:
+
+- **Assembling:** The leader uses an **`Assembler`** component to create a proposal (a block) from a batch of client requests, incorporating specific metadata like the hash of the previous block, which is then submitted to the consensus core.
+- **Verification:** Follower nodes receiving a proposal (via a consensus message) **must re-validate every transaction** within that proposal using a dedicated `Verifier` component, as they cannot trust the potentially malicious leader. This verification logic is injected via API functions (`VerifyProposal`, `VerifyRequest`) that wrap Fabric's existing validation capabilities.
+- **Decision Metadata:** The final "decision" delivered to the application (peer) includes the committed block _and_ the signatures of a quorum of ordering nodes ($Q=2F+1$). This ensures the peer is convinced the block was properly generated by a BFT service.
+
+## IV. Key Differences in Cluster Service Utilization
+
+The main differences in how etcdraft and SmartBFT utilize the Cluster Service are driven by their underlying fault tolerance models:
+
+|Feature|etcdraft (CFT)|SmartBFT (BFT)|
+|:--|:--|:--|
+|**Consensus Payload**|`raftpb.Message` (marshaled).|`smartbftprotos.Message` (marshaled).|
+|**Communication Wrapper**|Direct calls to `RPC` after processing in `Node.send`, often wrapped by `Disseminator`.|Uses a dedicated **`Egress`** component to implement the communication API required by the core BFT library.|
+|**Efficiency/Pipelining**|**Supports pipelining** blocks over gRPC streams, leading to high throughput. The stream is designed to drop messages if the node cannot keep up, prioritizing the system's FSM.|**Lacks pipelining**, as the BFT-SMART protocol proposes only one transaction/block at a time, resulting in reduced throughput compared to Raft.|
+|**Client Submission**|Clients submit to **one node** (leader or follower for forwarding). Forwarding uses `RPC.SendSubmit`.|Clients must **submit to all orderers** (the entire quorum) to prevent censorship attacks by a malicious leader.|
+|**Security Overhead**|Lower overhead; uses standard TLS and optional signature checks.|High overhead due to cryptographic computations (digital signatures) required for message verification in every phase of the BFT protocol.|
+|**Verification Role**|Followers trust the leader's proposal content and primarily ensure log synchronization.|Followers **must re-validate** the proposal's contents (transactions) against Fabric semantics during consensus using the `Verifier`.|
+
+---
+
+The **Cluster Service** in Hyperledger Fabric is the architectural layer that governs secure, authenticated, and reliable communication among ordering service nodes (OSNs), particularly those running cluster-based consensus protocols like etcdraft (Raft-OS) and SmartBFT (BFT-OS). It acts as a standard **gRPC-based transport layer** that decouples the core consensus logic from network management.
+
+## I. Core Components and Encapsulation
+
+The Cluster Service is managed by two primary entities: the **`AuthCommMgr`** (or `Comm`) on the client (sender) side, which manages connections and security, and the **`ClusterService`** on the server (receiver) side, which handles ingress traffic.
+
+### A. Communication Technology and Message Encapsulation
+
+1. **Transport:** The entire cluster communication relies on **gRPC**.
+2. **Authentication:** Communication is secured using **mutual TLS (mTLS)**. The `AuthCommMgr` establishes client-side connections and manages streams with the remote Cluster gRPC server, handling TLS session binding and identity verification.
+3. **Message Abstraction (RPC):** Consensus algorithms interact with the network via the **`cluster.RPC`** interface. This interface defines methods for sending two types of Fabric Protobuf messages over the gRPC stream, wrapped in an `orderer.StepRequest` payload:
+    - **`ConsensusOperation`:** Used for internal consensus messages (e.g., Raft messages, SmartBFT `PRE-PREPARE`/`COMMIT` messages).
+    - **`SubmitOperation`:** Used for forwarding client transaction requests.
+
+### B. Encapsulation Process (Egress)
+
+When a consensus library (like SmartBFT or etcdraft) generates an internal message (e.g., a `raftpb.Message` or a `smartbftprotos.Message`), the Fabric wrapper performs encapsulation before handing it off to the Cluster Service:
+
+1. **Serialization:** The internal consensus message (e.g., a BFT message) is marshaled into a byte payload.
+2. **Wrapping:** This payload is encapsulated within the Fabric `orderer.ConsensusRequest` structure.
+3. **Dispatch:** The message is then passed to the Cluster Service via **`cluster.RPC.SendConsensus(targetID, consensusRequest)`**. The `cluster.RPC` handles the transmission over the secure gRPC stream.
+
+The Cluster Service manages a **send buffer** (`sendBuff`) for each stream and channel. For consensus requests, the service is configured to **drop messages** if the remote node cannot keep up, preventing the sender's Finite State Machine (FSM) from slowing down.
+
+## IV. Dynamic Membership Management (Join and Leave)
+
+The Cluster Service, specifically the **`AuthCommMgr`** (or `Comm`), is solely responsible for implementing node joining and leaving. The core consensus algorithms (like Raft or SmartBFT) are only informed of their membership list (`Consenters`) but do not directly manage the underlying gRPC connections.
+
+This process is always triggered by the commitment of a new **Configuration Block** (`Config Block`) to the ledger, which contains an updated list of consenters.
+
+### A. The `Configure` Method
+
+The central method for membership management is `Configure(channel string, members []RemoteNode)` implemented by the `AuthCommMgr`.
+
+1. **Input:** The Fabric ordering node wrapper extracts the list of `Consenters` from the newly committed configuration block. It converts this list into a slice of `cluster.RemoteNode` structures, which contain the node's ID, endpoint (Host:Port), and necessary TLS certificates (Server Root CA, Server TLS Cert, Client TLS Cert).
+2. **Execution:** The `AuthCommMgr` locks its state, iterates through the new list of members, and updates its internal `MemberMapping` (a map of IDs to `Stub` objects).
+
+### B. Joining (or Adding) a Consenter
+
+When a new consenter node, say **OSN 4**, is added to a channel's configuration:
+
+1. **Configuration Block:** The Config Block is committed, listing OSN 1, OSN 2, OSN 3, and OSN 4 as consenters.
+2. **Update Stub:** For OSN 4, the `AuthCommMgr` detects that no `Stub` (representing the remote node) exists in its mapping. A new `Stub` is allocated and added to the `MemberMapping`.
+3. **Activation and Connection:** The `AuthCommMgr` calls `stub.Activate(ac.createRemoteContext(stub, channel))`.
+    - The `createRemoteContext` function looks up OSN 4's endpoint and TLS root certificates.
+    - It then calls the **`ConnectionsMgr.Connect()`** method, which establishes a new, secure **gRPC connection** to OSN 4's endpoint, verifies its server certificate, and caches the connection.
+    - A `RemoteContext` is created, which holds the necessary information to open subsequent gRPC streams to OSN 4.
+
+### C. Leaving (or Removing) a Consenter
+
+When an existing consenter, say **OSN 1**, is removed from the channel's configuration:
+
+1. **Configuration Block:** The Config Block is committed, listing only OSN 2, OSN 3, and OSN 4.
+2. **Detection:** The `AuthCommMgr` iterates over its _old_ membership list and identifies that OSN 1 is no longer present in the _new_ list (`newNodeIDs`).
+3. **Deactivation:** The `Stub` corresponding to OSN 1 is retrieved, and its `Deactivate()` method is called. `Deactivate` aborts any ongoing streams associated with the remote node (`RemoteContext.Abort()`).
+4. **Disconnection:** The `AuthCommMgr` calls **`ConnectionsMgr.Disconnect(stub.Endpoint)`** (or disconnects by certificate, depending on the implementation version). This method explicitly closes the gRPC connection and removes the endpoint from the connection cache (`ConnectionsCache`).
+
+### D. Example: 4 Consenter Cluster
+
+Consider a channel initially served by 4 consenters: C1, C2, C3, C4.
+
+1. **Initial State:** All four OSNs (C1-C4) have committed the initial configuration block. Each OSN's `AuthCommMgr` holds active gRPC connections (or stubs ready to activate connections) to the other 3 OSNs.
+2. **Scenario: C1 is Removed (Leaving):**
+    - A new configuration transaction is proposed and ordered, removing C1.
+    - OSNs C2, C3, and C4 commit this block.
+    - Each of C2, C3, and C4 runs `Comm.Configure(..., [C2, C3, C4])`.
+    - Their `AuthCommMgr` detects that C1 is absent in the new list. C1's stub is deactivated, and the direct gRPC connection to C1's endpoint is closed (`ConnectionsMgr.Disconnect`).
+    - **C1's Action (Self-Eviction):** C1 detects that it is no longer in the consenters set (either during Raft's `apply` phase or via eviction suspicion). C1's chain halts (`c.halt()`) and might switch to a follower role.
+3. **Scenario: C5 is Added (Joining):**
+    - A new configuration transaction is proposed and ordered, adding C5 (C1 remains removed: [C2, C3, C4, C5]).
+    - OSNs C2, C3, C4 commit this block.
+    - Each of C2, C3, and C4 runs `Comm.Configure(..., [C2, C3, C4, C5])`.
+    - The `AuthCommMgr` sees C5 is new. It resolves C5's endpoint and certificates, establishes a new gRPC connection via `ConnectionsMgr.Connect`, and activates the `Stub` for C5.
+    - The new node C5 joins the channel (via the `Registrar.JoinChannel` process), reads the config block, and runs `Comm.Configure(..., [C2, C3, C4, C5])`, establishing connections to C2, C3, and C4.
+
+This dynamic mechanism allows the ordering cluster to seamlessly adapt its authenticated communication structure whenever the agreed-upon channel configuration changes, ensuring that consensus messages only flow between authorized and currently active consenter nodes.
+
+
+----
+
+SmartBFT did not just passively import the `AuthCommMgr`; it required the construction of a comprehensive wrapper architecture that delegates all low-level networking, security, and membership management responsibilities to the `AuthCommMgr` and its related components. This custom integration addresses the key architectural problems that plagued previous BFT integration attempts.
+
+Here is a deep breakdown of what SmartBFT did to use the `AuthCommMgr`:
+
+## 1. Defining and Implementing the Communication Bridge (`Egress`)
+
+The core SmartBFT consensus library is designed to be transport-agnostic, delegating communication functions (point-to-point authenticated channels) to the application employing it. This delegation is crucial because the BFT library, being a state machine, cannot contain logic for gRPC connections, TLS, or authentication.
+
+### A. The Egress Component
+
+SmartBFT created an **`Egress`** structure which serves as the implementation of the communication interface required by the core BFT consensus library.
+
+- **RPC Reference:** The `Egress` structure holds a reference to the Fabric Cluster **`RPC`** interface. The `RPC` interface defines the high-level methods used for sending consensus and submit requests over the gRPC transport.
+- **The Translation Layer:** When the core SmartBFT consensus library determines a message (like a `PRE-PREPARE` or `COMMIT` message) needs to be sent, it calls a method on the `Egress`. The `Egress` then:
+    1. Receives the native SmartBFT message (`*smartbftprotos.Message`).
+    2. Translates/marshals this message payload.
+    3. Encapsulates the payload into a standardized Fabric `orderer.ConsensusRequest` structure via the `bftMsgToClusterMsg` function.
+- **Delegating to RPC:** Finally, the `Egress` component calls the `SendConsensus` method on the Fabric `RPC` object, providing the target node ID and the fully encapsulated message: `e.RPC.SendConsensus(targetID, clusterMsg)`.
+
+This **`cluster.RPC`** instance is instantiated within the SmartBFT chain initialization and is configured to use the main Fabric **`AuthCommMgr`** (`c.Comm` field).
+
+## 2. Delegation of Security and Authentication to `AuthCommMgr`
+
+The SmartBFT developers noted that previous BFT attempts failed because the BFT cluster signatures were not compliant with Fabric's security mechanisms, and the BFT server identities were not integrated into Fabric's configuration.
+
+To use the `AuthCommMgr` successfully, SmartBFT delegated the following security roles:
+
+- **Identity Management:** The `AuthCommMgr` is initialized with the local node's serialized identity (`NodeIdentity`) and the `Signer` (from `SignerSerializer`). This ensures that the cryptographic identity used for inter-node communication is Fabric-compliant.
+- **mTLS and Stream Authentication:** When the `RPC` interface (used by `Egress`) calls `AuthCommMgr.Remote()`, the `AuthCommMgr` manages the secure connection. It uses the `ConnectionsMgr` to establish the gRPC connection, which secures communication using **mTLS**. The `AuthCommMgr` also ensures that the stream is properly authenticated (via `Auth()` on the client stream) using the node's identity and TLS session binding. This eliminates the need for the consensus protocol to implement custom, potentially conflicting, key authentication protocols (like the custom TCP/ECDH mechanism seen in the BDLS POC sources).
+
+## 3. Delegation of Membership Management (`Configure`)
+
+In a cluster environment, the list of active consenter nodes (the topology) frequently changes via configuration blocks. SmartBFT delegates the management of gRPC connections associated with this topology entirely to the `AuthCommMgr`.
+
+- **Config Block Trigger:** When a configuration block is committed, the SmartBFT chain wrapper (`BFTChain`) detects the change.
+- **Dynamic Configuration:** The chain updates its internal runtime configuration (`RuntimeConfig`) based on the new block and then invokes the core membership management method on the `AuthCommMgr`: `c.Comm.Configure(c.Channel, newRTC.RemoteNodes)`.
+- **`AuthCommMgr` Action:** The `AuthCommMgr`'s `Configure` method handles the complex tasks of `Join` and `Leave` by:
+    - Iterating over the new list of nodes (`members`) and updating its internal `MemberMapping` (map of IDs to `Stub` objects).
+    - **Joining/Activation:** For new members, the `AuthCommMgr` resolves their connection criteria (endpoint, TLS CAs) and establishes a new gRPC connection using the `ConnectionsMgr.Connect()` method.
+    - **Leaving/Deactivation:** For nodes removed from the channel membership, the `AuthCommMgr` calls `stub.Deactivate()` (aborting streams) and uses `ConnectionsMgr.Disconnect()` to close the unused gRPC connections.
+
+By externalizing these complex, non-deterministic tasks to the `AuthCommMgr` via the `Egress` wrapper, SmartBFT avoids implementing custom networking and fully integrates its consensus output with Fabric's gRPC transport layer.
+
+---
+
+The `Configure` function in the Hyperledger Fabric Cluster Service (`cluster.AuthCommMgr` or `cluster.Comm`) is the primary mechanism responsible for **dynamically updating the topology** (the set of connected ordering nodes) for a specific channel based on changes in the channel configuration block.
+
+It serves as the mechanism for nodes to **join** a channel's consenter set (establishing new gRPC connections) and for other nodes to **leave** the cluster (closing unused gRPC connections).
+
+Here is a detailed explanation of what the `Configure` function does, analyzed using relevant code structures from the sources:
+
+## I. `Configure` Function Definition and Structure
+
+The `Configure` method is part of the `Communicator` interface and is implemented within the `AuthCommMgr` (or `Comm`):
+
+```
+// Configure configures the communication to connect to all
+// given members, and disconnect from any members not among the given
+// members.
+func (c *Comm) Configure(channel string, newNodes []cluster.RemoteNode) {
+    c.Logger.Infof("Entering, channel: %s, nodes: %v", channel, newNodes)
+
+    // 1. Ensure thread safety before modifying shared connection maps
+    c.Lock.Lock()
+    defer c.Lock.Unlock()
+
+    // ... shutdown checks ...
+
+    // 2. Take a snapshot of current connections
+    beforeConfigChange := c.serverCertsInUse()
+
+    // 3. Update the channel-scoped mapping with the new nodes (JOINING/ACTIVATION)
+    c.applyMembershipConfig(channel, newNodes)
+
+    // 4. Close connections to nodes that are not present in the new membership (LEAVING)
+    c.cleanUnusedConnections(beforeConfigChange)
+
+    defer c.Logger.Infof("Exiting")
+}
+```
+
+This function performs two main, synchronized tasks: ensuring all necessary new connections are established or updated, and ensuring all old, unnecessary connections are closed.
+
+## II. Joining and Updating Nodes (`applyMembershipConfig`)
+
+The `c.applyMembershipConfig` helper function iterates over the desired list of consenters (`newNodes`) and ensures that local representations (stubs) and, if necessary, gRPC connections exist for each one. This handles the "joining" process for newly added nodes.
+
+### 1. Updating the Stub Mapping
+
+The `applyMembershipConfig` ensures that a mapping structure exists for the given channel (`mapping := c.getOrCreateMapping(channel)`). It then iterates over the `newNodes` to update or create **Stubs**.
+
+In the analogous `AuthCommMgr.Configure` implementation, this involves a loop:
+
+```
+for _, node := range members {
+    newNodeIDs[node.ID] = struct{}{} // Record the new set of IDs
+    ac.updateStubInMapping(channel, mapping, node) // Update local structure
+}
+```
+
+### 2. Activating/Connecting the Remote Context
+
+If a node is new, its corresponding `Stub` is activated, which triggers the connection logic:
+
+```
+// Inside updateStubInMapping, if the stub is not active:
+if !stub.Active() { //
+    // Activate the stub, creating the necessary remote context
+    stub.Activate(ac.createRemoteContext(stub, channel)) //
+}
+
+// Inside ac.createRemoteContext:
+conn, err := ac.Connections.Connect(stub.Endpoint, stub.RemoteNode.ServerRootCA)
+// Connect establishes a new gRPC connection using mTLS if one does not exist.
+```
+
+The `createRemoteContext` function uses the node's endpoint and Server Root CA to request a secure gRPC connection via the underlying `ConnectionsMgr` (or `ConnectionStore`). This successfully establishes the necessary gRPC transport link for the new consenter node.
+
+## III. Leaving and Disconnecting Nodes (`cleanUnusedConnections`)
+
+This step ensures connections to nodes that have been removed from the channel are gracefully shut down, minimizing resource usage.
+
+### 1. Identifying Unused Certificates
+
+This relies on comparing the topology before and after the configuration update:
+
+```
+// 1. Scan all nodes after the reconfiguration
+serverCertsAfterConfig := c.serverCertsInUse()
+
+// 2. Filter out the certificates that remained after the reconfiguration
+serverCertsBeforeConfig.subtract(serverCertsAfterConfig) //
+// The resulting 'serverCertsBeforeConfig' now holds only the certificates
+// (keyed by serialized certificate bytes) that are no longer needed by ANY channel.
+```
+
+### 2. Disconnecting the gRPC Connection
+
+The `Comm` iterates over this filtered set of old certificates and explicitly tells the connection manager to close the connections:
+
+```
+// Close the connections to all these nodes as they shouldn't be in use now
+for serverCertificate := range serverCertsBeforeConfig {
+    c.Connections.Disconnect([]byte(serverCertificate)) //
+}
+
+// Inside ConnectionsMgr.Disconnect (using ConnByCertMap for keying):
+// conn, connected := c.Connections.Lookup(endpoint) //
+// if !connected { return }
+// conn.Close() // Gracefully close the gRPC connection
+// c.Connections.Remove(endpoint) // Remove from the cache
+```
+
+The invocation of `Disconnect` handles acquiring internal locks, locating the specific gRPC client connection object (`*grpc.ClientConn`), calling `Close()`, and removing it from the cache. This completes the "leaving" process at the network level.
+
+## IV. Usage in BDLS (BDLS POC Code)
+
+In the BDLS POC, the `Configure` function is invoked within the `NewChain` constructor (the Fabric wrapper initialization logic) using the `Comm` object injected into the chain structure. This ensures the node immediately establishes communication links with its peers after reading the channel configuration:
+
+```
+// From BDLS chain.go/NewChain initialization:
+// nodes, err := c.remotePeers() // Gathers endpoints and certificates from consenters list
+// if err != nil { return nil, errors.WithStack(err) }
+// c.Comm.Configure(c.support.ChannelID(), nodes) //
+```
+
+The BDLS implementation relies entirely on this **`c.Comm.Configure`** call to manage all inter-orderer gRPC communication, demonstrating that the Cluster Service is responsible for network topology and connection lifecycle management. A similar explicit invocation is present in the BDLS `configureComm` function to handle reconfiguration after consensus.
+
+----
+
+The **`Configure(channel string, members []RemoteNode)`** method, which belongs to the Fabric Cluster Service's `Communicator` interface (implemented by `cluster.AuthCommMgr` or `cluster.Comm`), is called by the **consensus implementation wrapper (the Chain object)** whenever the channel's membership or configuration changes.
+
+This method handles the underlying management of gRPC connections for the ordering nodes.
+
+Based on the provided sources for both SmartBFT and the BDLS Proof of Concept (which follows similar architectural patterns), the `Configure` method is called in three primary contexts:
+
+---
+
+## 1. Initial Chain Creation (`NewChain`)
+
+The `Configure` method is called immediately when a channel chain object is first created and initialized on an ordering service node (OSN). This establishes the initial communication links to all known consenters in the cluster.
+
+### A. BDLS Implementation Example
+
+In the BDLS implementation, the `NewChain` function explicitly calculates the remote peer list and calls `c.Comm.Configure`:
+
+```
+// Code within orderer/consensus/bdls/chain.go's NewChain function:
+nodes, err := c.remotePeers()
+if err != nil {
+    return nil, errors.WithStack(err)
+}
+//
+c.Comm.Configure(c.support.ChannelID(), nodes) //
+```
+
+- **Who calls it:** The `NewChain` function, which creates the channel-specific `Chain` object. The `NewChain` function is returned by the `HandleChain` function of the `Consenter` interface implementation.
+- **Purpose:** To set up the initial communication paths based on the `Consenters` listed in the last configuration block available to the chain.
+
+### B. SmartBFT Implementation Example
+
+The SmartBFT implementation follows an identical pattern in its `NewChain` function:
+
+```
+// Code within orderer/consensus/smartbft/chain.go's NewChain function:
+// Setup communication with list of remotes notes for the new channel
+c.Comm.Configure(c.support.ChannelID(), rtc.RemoteNodes) //
+```
+
+- **Who calls it:** The `NewChain` function, which sets up the BFT chain object.
+
+## 2. Dynamic Membership Reconfiguration
+
+The `Configure` method is called every time a new **Configuration Block** is committed to the ledger that potentially alters the membership list (`Consenters`) or network topology of the channel.
+
+### A. SmartBFT Implementation Example
+
+In SmartBFT, reconfiguration is triggered by the core consensus library through an external commitment function hook, `OnCommit`.
+
+- **Who calls it:** The **`updateRuntimeConfig`** function within the `BFTChain` (the SmartBFT chain implementation).
+- **When:** The `updateRuntimeConfig` is executed after a block is delivered and committed via the `Deliver` or `Sync` calls.
+- **Condition:** If the newly committed block is a **Config Block** (`protoutil.IsConfigBlock(block)`), the `BFTChain` updates its internal `RuntimeConfig` and then calls `Configure` to update the connection manager with the new node list:
+
+```
+// Inside BFTChain.updateRuntimeConfig:
+if protoutil.IsConfigBlock(block) {
+    // Update Comm with new remote nodes
+    c.Comm.Configure(c.Channel, newRTC.RemoteNodes) //
+
+    // Also updates the receiving side (ClusterService)
+    c.clusterService.ConfigureNodeCerts(c.Channel, newRTC.consenters) //
+}
+```
+
+### B. etcdraft Implementation Example
+
+In etcdraft (Raft-OS), reconfiguration is also handled post-commit, specifically after a Raft Configuration Change (`ConfChange`) is applied and processed:
+
+- **Who calls it:** The **`c.configureComm()`** helper function, which is executed after applying an entry.
+- **When:** The `configureComm` function is triggered within `c.commitBlock` when a configuration block is written and within the `c.apply(ents []raftpb.Entry)` routine when a `raftpb.EntryConfChange` is successfully applied to the Raft state machine.
+
+```
+// Inside etcdraft chain.go's configureComm function:
+// 1. Gathers the current list of remote peers:
+// nodes, err := c.remotePeers() //
+// 2. Calls the Communicator:
+// c.configurator.Configure(c.channelID, nodes) //
+```
+
+## 3. Dedicated Wrapper Function (`configureComm` in BDLS)
+
+The BDLS implementation, like etcdraft, includes a dedicated function, **`c.configureComm()`**, which wraps the `Comm.Configure` call. This function is designed to be called whenever the chain needs to reset its communication view, ensuring the underlying `AuthCommMgr` refreshes its connections based on the latest consenter list.
+
+- **Who calls it:** The BDLS `Chain` object.
+- **When:** Potentially after a synchronization event or error recovery, as seen by its presence in the BDLS source.
+---
+
+
+The key lies in the fact that the **consensus protocol itself** must validate and commit the configuration block to the ledger, and then execute a hook (`OnCommit` or equivalent) that checks the committed block's contents.
+
+Here is a detailed explanation of how a new Configuration Block triggers the `Configure` method in a clustering consensus implementation, using the SmartBFT and BDLS POC architecture as primary examples:
+
+## How a Configuration Block Triggers `Comm.Configure(...)`
+
+The process involves a strict sequence of steps managed by the Fabric orderer wrapper (`Chain` object) after a Configuration Block is finalized by the cluster:
+
+### Step 1: Consensus and Commitment of the Block
+
+The Configuration Transaction is ordered by the consensus protocol (e.g., SmartBFT or etcdraft) and packed into a block, becoming a **Configuration Block**. The block is then finalized and delivered to the local ledger.
+
+- **BDLS/SmartBFT:** The consensus core (BDLS or SmartBFT) delivers the finalized block (the "decision") to the application wrapper via the `Deliver` method.
+- **Writing the Block:** The `Deliver` function ensures the block is written to the ledger using `c.support.WriteConfigBlock(block, nil)`. This step commits the new configuration to the local node's immutable ledger.
+
+### Step 2: Invocation of the Runtime Configuration Update Hook
+
+Immediately after the Configuration Block is written to the ledger, the consensus chain executes a post-commit routine (a "hook") to update its runtime settings.
+
+- **SmartBFT Hook:** In SmartBFT, the `Deliver` method calls the `c.updateRuntimeConfig(block)` function.
+- **Etcdraft Hook:** In etcdraft, the `c.commitBlock(block)` function detects the config change and calls `c.configureComm()`.
+- **BDLS Hook:** The BDLS POC also has a dedicated `c.configureComm()` helper which is invoked, and the BDLS chain updates its `RuntimeConfig` via `updateRuntimeConfig`.
+
+### Step 3: Detecting the Membership Change
+
+The post-commit function (`updateRuntimeConfig` or `configureComm`) analyzes the committed block to see if the consenter set has changed.
+
+- **Parsing the Block:** The function must first determine if the block is a Configuration Block (`protoutil.IsConfigBlock(block)`).
+- **Extracting Consenters:** If it is a Configuration Block, the function extracts the new configuration bundle, specifically obtaining the updated list of `Consenters` from the Orderer configuration section. In SmartBFT, this results in the creation of a `newRTC` (RuntimeConfig) object containing the new `RemoteNodes`.
+
+### Step 4: Calling `Comm.Configure` to Update gRPC Connections
+
+If the membership list is new or updated, the `AuthCommMgr` (referred to as `c.Comm` in the chain object) is invoked with the new list of nodes.
+
+- **The Call:** The consensus chain wrapper explicitly calls the `Configure` method on its `cluster.Communicator` instance:
+
+```
+// SmartBFT/BDLS implementation of the reconfiguration call:
+// The Comm object holds the AuthCommMgr configured during initialization
+if protoutil.IsConfigBlock(block) {
+    c.Comm.Configure(c.Channel, newRTC.RemoteNodes) //
+    // Additionally, the receiving side (ClusterService) is refreshed
+    c.clusterService.ConfigureNodeCerts(c.Channel, newRTC.consenters) //
+}
+```
+
+- **Who is the `Comm`?** The `c.Comm` object is an instance of `cluster.AuthCommMgr` or `cluster.Comm`, which implements the `Communicator` interface.
+- **`Configure` Action:** This function handles the actual network topology changes:
+    - It iterates over the new list of members (`newNodes`) and activates corresponding stubs, establishing new gRPC connections via the `ConnectionsMgr` (`Connect`) if a node is new (joining).
+    - It compares the old membership state (`beforeConfigChange`) with the new one and calls `cleanUnusedConnections`. This helper then iterates over unused server certificates and calls `c.Connections.Disconnect` to close the old gRPC connections (leaving).
+
+In summary, the consensus chain's commitment routine acts as the **trigger**, reading the updated membership list from the **Configuration Block** and forcing the Cluster Service (via `c.Comm`) to synchronize its gRPC network topology to match the agreed-upon configuration.
+
+
+----
+
+The `Deliver` method is a critical interface function within the Hyperledger Fabric ordering service architecture, particularly in **Byzantine Fault Tolerant (BFT)** consensus implementations like SmartBFT. It marks the **end of the request life-cycle** within the consensus library and serves as the primary hook for the application layer (the Fabric orderer wrapper) to accept a finalized block and commit it to the ledger.
+
+The goal of the ordering service, generally, is to deliver blocks containing ordered transactions to the committer peers. The `Deliver` method is the mechanism by which the consensus mechanism fulfills this mandate at the ordering node itself.
+
+Here is a detailed breakdown of what the `Deliver` method does, based on the SmartBFT/BDLS architecture:
+
+## I. Core Responsibilities and Invocation
+
+The `Deliver` method is implemented by the Fabric orderer wrapper (e.g., `BFTChain.Deliver` in SmartBFT or the equivalent logic in the BDLS POC, often channeled through the `applyC` channel) and is **invoked by the core consensus library**.
+
+### A. Trigger Condition
+
+The core consensus library calls `Deliver` when a decision has been reached. Specifically, for BFT protocols, `Deliver` is invoked when a node receives a **quorum of `COMMIT` messages** ($Q = 2F + 1$) for a specific proposal (block).
+
+### B. Parameters and Output
+
+The `Deliver` function receives two main inputs and returns a single structure:
+
+1. **`Proposal` (Block):** This is the block structure containing the finalized, ordered batch of transactions. In the BFT context, this block has already been verified by the followers during the consensus phases (`PRE-PREPARE`/`PREPARE`).
+2. **`[]Signature` (Quorum Signatures):** This is the collection of cryptographic signatures from the quorum of ordering nodes ($Q=2F+1$ signatures) that committed the block. The block along with these commit signatures is called the "decision".
+3. **`Reconfig` (Return Value):** The application (Fabric) uses the return value, `Reconfig`, to inform the consensus library whether any of the transactions in the delivered block **reconfigured the library** (i.e., changed the membership or consensus options).
+
+## II. Actions Performed by the Application Wrapper
+
+Once `Deliver` is invoked on the Fabric orderer wrapper, it performs the following critical tasks:
+
+### 1. Finalizing and Writing the Block
+
+The primary task is committing the block to the ledger.
+
+- **Metadata Assembly:** The wrapper takes the committed `Proposal` and integrates the accompanying quorum `Signatures` into the block's metadata field (specifically the `SIGNATURES` index).
+- **Ledger Commitment:** The wrapper then writes the fully formed block to the ledger using the underlying support functionality:
+    - If it is a **Normal Block**, it calls `c.support.WriteBlock(block, nil)`.
+    - If it is a **Configuration Block**, it calls `c.support.WriteConfigBlock(block, nil)`.
+- **State Persistence:** The application is responsible for **storing the delivered decision**, as the consensus library may dispose of this data once `Deliver` returns.
+- **Metrics:** The `Deliver` implementation often includes updating metrics, such as reporting the newly committed block number.
+
+### 2. Handling Runtime Configuration Changes
+
+The `Deliver` method is the critical juncture for implementing dynamic reconfiguration, ensuring the consensus cluster topology remains synchronized with the channel configuration.
+
+- **Calling the Update Hook:** The `Deliver` implementation calls an internal function, such as `c.updateRuntimeConfig(block)`, immediately after committing the block.
+- **Checking for Reconfiguration:** This update hook checks if the committed block is a configuration block (`protoutil.IsConfigBlock(block)`).
+- **Triggering Cluster Service Update:** If a membership change (a reconfiguration) is detected, the `updateRuntimeConfig` function extracts the new list of consenters and invokes the Cluster Service's topology management function: `c.Comm.Configure(c.Channel, newRTC.RemoteNodes)` (analogous to how `Configure` is called after detecting configuration changes in BDLS/etcdraft).
+
+## III. Distinction from Raft Delivery
+
+While Raft also delivers blocks for commitment, the BFT `Deliver` mechanism is unique due to security requirements:
+
+- **Signature Placement:** In Raft-OSN, the delivered block is signed **after** consensus by the node, right before it is saved to the block store. In SmartBFT, the block is signed **during** the consensus protocol (in the commit phase) by $Q$ nodes, and these $Q$ signatures are delivered _with_ the block via the `Deliver` method.
+- **Purpose of Signatures:** The signatures delivered in SmartBFT's `Deliver` method are necessary for the peer to validate the block against the BFT validation policy, proving the block was properly generated by a quorum of ordering nodes.
+---
+
+The process of an ordering node (OSN-New) being added to a Hyperledger Fabric channel is complex, involving strict checks against the channel configuration and the activation of the underlying gRPC Cluster Service (`AuthCommMgr`). Since the modern architecture (used by SmartBFT and the BDLS POC) relies on the Channel Participation API, the cycle is initiated by the node receiving a configuration block and attempting to join, rather than being passively instructed by a System Channel.
+
+The following steps trace the process from the initial join request to the node becoming a fully active consenter, utilizing the BDLS/SmartBFT architecture as an example.
+
+---
+
+## The Cycle of an Orderer Joining a Channel
+
+### Step 0: External Trigger (Initial Configuration)
+
+Before the joining process begins, a configuration block must exist that lists the OSN-New's certificate and endpoint among the channel's **`Consenters`**. This configuration block is typically delivered to the OSN-New via the **`Registrar.JoinChannel`** API.
+
+|Trace|Function/Component|Action|
+|:--|:--|:--|
+|**Call**|`Registrar.JoinChannel(ChannelID, ConfigBlock)`|The Fabric orderer's external API receives the configuration block containing the new consenter set.|
+
+### Step 1: Registrar Validation and Consensus Initialization
+
+The `Registrar` acts as the gatekeeper, checking security and initiating the consensus module specific to the channel (e.g., BDLS or SmartBFT).
+
+|Trace|Function/Component|Action|
+|:--|:--|:--|
+|**Call**|`r.initLedgerResourcesClusterConsenter(configBlock)`|Initializes the necessary ledger support structures and retrieves the specific consensus implementation (the `Consenter`).|
+|**Call**|`clusterConsenter.IsChannelMember(joinBlock)`|The consensus implementation (e.g., BDLS Consenter) checks if the node's local identity (`c.Identity`) matches any consenter identity listed in the configuration block. This must return `true` for the join to proceed as a member.|
+|**Call**|`r.createAsMember(ledgerRes, configBlock, channelID)`|If the membership check passes, the Registrar creates the full Consenter Chain object.|
+|**Trace**|`newChainSupport(...)` -> `Consenter.HandleChain(...)`|The `createAsMember` logic invokes the BDLS/SmartBFT `Consenter.HandleChain` method, beginning the internal protocol setup.|
+
+### Step 2: Protocol Chain Initialization (`NewChain`)
+
+The `HandleChain` function proceeds to create the protocol-specific chain implementation (e.g., `BDLS.Chain` or `SmartBFT.BFTChain`). This is where the local node ID is determined and all communication channels are set up.
+
+|Trace|Function/Component|Action|
+|:--|:--|:--|
+|**Call**|`BDLS.Consenter.detectSelfID(consenters)`|Determines the node's unique numerical ID (`selfID`) within the consenter set based on its certificate.|
+|**Call**|`NewChain(...)`|Initializes the `Chain` structure, setting up internal channels (`c.applyC`, `c.submitC`, `c.haltC`) and external support components (`BlockPuller`, `Verifier`).|
+
+### Step 3: Cluster Service Configuration (gRPC Activation)
+
+This is the critical step where the node establishes its secure communication paths to its peers using gRPC, enabling the **joining** of the cluster topology.
+
+|Trace|Function/Component|Action|
+|:--|:--|:--|
+|**Call**|`c.remotePeers()`|The chain extracts the endpoint addresses and TLS certificates of all current `Consenters` from the channel configuration block.|
+|**Call**|**`c.Comm.Configure(c.support.ChannelID(), nodes)`**|The BDLS/SmartBFT chain calls the Cluster Service `Communicator` (`c.Comm`, which is an `AuthCommMgr`) with the extracted list of remote nodes.|
+|**Action**|`AuthCommMgr.Configure(...)`|The `AuthCommMgr` iterates over the `newNodes` list: it creates a `Stub` for each remote OSN and calls `stub.Activate()`.|
+|**Trace**|`stub.Activate(...)` -> `ac.Connections.Connect(Endpoint, ServerRootCA)`|The `AuthCommMgr` requests the underlying `ConnectionsMgr` to establish a new, secure **gRPC connection (mTLS)** to every peer in the consenter set.|
+
+### Step 4: Starting the Consensus Runtime
+
+After initialization, the `Chain` must start its internal event loops and consensus processes in separate goroutines.
+
+|Trace|Function/Component|Action|
+|:--|:--|:--|
+|**Call**|`chain.start()`|Invoked by the `Registrar` after `newChainSupport` returns.|
+|**Call**|`BDLS.Chain.Start()`|Closes the start channel (`close(c.startC)`) and launches two main goroutines: `go c.startConsensus(...)` and `go c.run()`.|
+|**Action**|`c.startConsensus()` (Leader/Proposal Loop)|This goroutine initializes the core BDLS state machine and begins the process of watching for consensus events. In the case of the POC, this includes custom TCP initialization (which should be refactored).|
+|**Action**|`c.run()` (Application Event Loop)|This goroutine runs the main `select` loop, monitoring the `c.submitC` channel (for new transactions) and the `c.applyC` channel (for committed blocks from the consensus core).|
+
+### Step 5: Synchronization and Catch-Up (Initial Block Pulling)
+
+Since the newly joined node likely has an outdated ledger height (Height < latest cluster height), it must synchronize its ledger using the Block Puller service.
+
+|Trace|Function/Component|Action|
+|:--|:--|:--|
+|**Action**|Consensus Core Check (`Sync`)|Upon starting, the BDLS/SmartBFT consensus core detects that it is behind the cluster's frontier of delivered decisions.|
+|**Call**|`c.BlockPuller.PullBlock(seq)`|The synchronizer requests blocks starting from the node's current height (`c.lastBlock.Header.Number + 1`) up to the height reported by its peers (`HeightsByEndpoints`).|
+|**Action**|`BlockPuller.obtainStream(...)` -> `seekNextEnvelope(startSeq)`|The `BlockPuller` creates a signed `DELIVER_SEEK_INFO` envelope and initiates a gRPC stream (Deliver stream) with a remote OSN to pull the missing blocks sequentially.|
+|**Action**|`c.writeBlock(block, index)`|As blocks are received via the pull stream, they are committed to the local ledger (Block Store).|
+
+### Step 6: Active Participation (N+1)
+
+Once the synchronization completes, the node is fully caught up and transitions to an active consenter role.
+
+| Trace      | Function/Component                          | Action                                                                                                                                                                                                                                                                                          |
+| :--------- | :------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Action** | `c.run()` Loop Activation                   | The `select` loop begins actively listening for new client proposals via `s := <-submitC`.                                                                                                                                                                                                      |
+| **Action** | Handling Client Requests (`BFT` model)      | The client (modified SDK) submits the transaction request to all ordering nodes (the quorum).                                                                                                                                                                                                   |
+| **Trace**  | `c.Order/Configure(...)` -> `c.submit(...)` | The Fabric chain wrapper receives the request and sends it to the submission channel: `c.submitC <- &submit{req}`.                                                                                                                                                                              |
+| **Action** | Full Participation                          | The newly joined node now processes requests, participates in the BFT phases (propose, lock, commit, decide), and contributes its signature to the final block decision. The consensus protocol relies on the established gRPC connections (managed by `AuthCommMgr`) for all message exchange. |
+
+---
+The process of adding a new ordering node (OSN-New) to an existing Hyperledger Fabric channel using the **SmartBFT** consensus protocol is a comprehensive sequence that leverages the existing gRPC Cluster Service (`AuthCommMgr`) for secure connection management. The process ensures that the new node is authenticated, configured correctly, and synchronized before actively participating in the Byzantine Fault Tolerant (BFT) consensus.
+
+The SmartBFT implementation differs from simpler CFT protocols because every step requires cryptographic verification and adherence to BFT security rules.
+
+---
+
+## Step 0: External Trigger and Membership Check
+
+The process is initiated when the OSN-New is provided with a configuration update that lists it among the **`Consenters`** for the target channel.
+
+|Step|Component & Trace|Action Description|
+|:--|:--|:--|
+|**0.1**|`Registrar.JoinChannel(ChannelID, ConfigBlock)`|The Fabric node's Registrar receives the Configuration Block, which includes the new list of consenters (containing OSN-New's certificate/identity).|
+|**0.2**|`SmartBFT.Consenter.IsChannelMember(joinBlock)`|The BFT Consenter implementation verifies the OSN-New's local identity (`c.Identity`) against the identities listed in the configuration block's consenter set. This check must pass for the join to proceed as a full member.|
+|**0.3**|`Consenter.HandleChain(...)`|If verification succeeds, the Registrar calls the BFT `Consenter.HandleChain` method to initialize the channel-specific consensus chain.|
+
+## Step 1: Chain Initialization and Configuration Parsing
+
+The `HandleChain` function sets up the required BFT environment, including communication hooks and configuration extraction.
+
+|Step|Component & Trace|Action Description|
+|:--|:--|:--|
+|**1.1**|`SmartBFT.Consenter.detectSelfID(consenters)`|The node determines its unique numerical ID (`selfID` of type `uint64`) by matching its certificate against the `Consenters` list.|
+|**1.2**|`SmartBFT.NewChain(...)`|The BFT chain object (`BFTChain`) is created, receiving necessary components like the `cluster.Communicator` (`comm`).|
+|**1.3**|`rtc.BlockCommitted(lastConfigBlock, bccsp)`|The `RuntimeConfig` (`rtc`) structure is populated by parsing the configuration block, extracting BFT-specific options (like batch sizes, timeouts) and the list of remote nodes (`RemoteNodes`).|
+
+## Step 2: Cluster Service Activation (The "Join" Phase)
+
+This is the critical step where the `AuthCommMgr` establishes the secure gRPC transport links to all peers, allowing the OSN-New to join the communication topology.
+
+|Step|Function Call & Component|Action Description (gRPC Activation)|
+|:--|:--|:--|
+|**2.1**|`c.Comm.Configure(c.support.ChannelID(), rtc.RemoteNodes)`|Within the `NewChain` function, the `BFTChain` explicitly calls the `Configure` method on the injected `cluster.Communicator` (`c.Comm`) using the latest list of remote nodes (`rtc.RemoteNodes`).|
+|**2.2**|`AuthCommMgr.Configure(...)`|The `AuthCommMgr` takes over network management. It iterates over all remote OSNs listed in `rtc.RemoteNodes` (which include endpoint addresses and TLS certificates).|
+|**2.3**|`AuthCommMgr.Connections.Connect(...)`|For each peer, the `AuthCommMgr` verifies if an active gRPC connection already exists. Since OSN-New is joining, new connections are typically established and authenticated using **mTLS** (mutual TLS).|
+|**Result**|Secure Topology|The node is now logically and physically connected to all other consenters via secure gRPC streams, managed entirely by the Fabric Cluster Service infrastructure.|
+
+## Step 3: Consensus Engine Start and Hook Integration
+
+The core BFT state machine is initialized and linked to the Fabric components.
+
+|Step|Function Call & Component|Action Description|
+|:--|:--|:--|
+|**3.1**|`c.consensus = bftSmartConsensusBuild(c, requestInspector)`|The `BFTChain` builds the core SmartBFT consensus object (`*smartbft.Consensus`), injecting the wrapper object (`c`) as the application and providing necessary hooks.|
+|**3.2**|**`Comm` Interface Implementation**|The SmartBFT core uses the **`Egress`** structure to handle communication. The `Egress` uses the `c.Comm` (AuthCommMgr) reference indirectly via `cluster.RPC` to send consensus messages (e.g., `e.RPC.SendConsensus`) over the newly established gRPC connections.|
+|**3.3**|**`chain.Start()`**|The consensus chain starts the BFT core: `c.consensus.Start()`.|
+|**3.4**|`c.reportIsLeader()`|The chain reports its initial leadership status (likely follower, 0) and the cluster size metric.|
+
+## Step 4: Synchronization and Catch-Up
+
+The new node detects its ledger height is behind the cluster and performs synchronization to catch up.
+
+|Step|Function Call & Component|Action Description|
+|:--|:--|:--|
+|**4.1**|`Synchronizer.Sync()`|The BFT core consensus library initiates the synchronization process, typically by calling the `Synchronizer.Sync()` method, as this is critical for BFT protocols to ensure all nodes start from the same state.|
+|**4.2**|`BlockPuller.PullBlock(seq)`|The `Synchronizer` uses the **`BlockPuller`** (which is also configured using the Cluster Service's network capabilities) to request missing blocks sequentially from peers.|
+|**4.3**|`c.support.WriteBlock(block, nil)`|As blocks are successfully pulled and verified (against the BFT validation policy), the node writes them to its local ledger.|
+
+## Step 5: Active Participation and Reconfiguration Handling
+
+Once synchronized, the node becomes fully active, ready to process transactions and handle future topology changes.
+
+| Step    | Function Call & Component | Action Description                                                                                                                                                                                                         |
+| :------ | :------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **5.1** | Client Submission         | Clients (using the modified SDK) submit transactions to the OSN-New.                                                                                                                                                       |
+| **5.2** | `BFTChain.Order(...)`     | The transaction is received by the chain's `Order` function and submitted to the consensus core via `c.submit(...)`.                                                                                                       |
+| **5.3** | **Consensus Execution**   | The node participates actively in the BFT consensus phases (PRE-PREPARE, PREPARE, COMMIT). All inter-node messages flow through the gRPC streams managed by the `AuthCommMgr` (via the `Egress` layer).                    |
+| **5.4** | `BFTChain.Deliver(...)`   | When a new Configuration Block is committed, the consensus core calls `Deliver(proposal, signatures)`. This writes the block.                                                                                              |
+| **5.5** | **`updateRuntimeConfig`** | The delivery hook calls `c.updateRuntimeConfig(block)`. If a change is detected, this function calls **`c.Comm.Configure(...)`** again to update the gRPC connections, handling the "leaving" or "joining" of other nodes. |
+
+
+----
+
+The integration of a new ordering node (OSN-New) into a Hyperledger Fabric channel running the **etcdraft (Raft-OS)** consensus protocol is a systematic process designed to ensure the Crash Fault Tolerant (CFT) cluster maintains quorum, securely updates its topology, and efficiently brings the new node into sync. This process heavily relies on the Fabric Cluster Service's `AuthCommMgr` for secure gRPC connection management.
+
+The etcdraft approach is distinct from SmartBFT in that it focuses on replicating a log and relies on the underlying Raft FSM, which primarily operates using numerical IDs and raw Raft messages.
+
+Here is a step-by-step cycle of an orderer being added to an etcdraft channel:
+
+## Step 0: External Trigger (Configuration and Join)
+
+The process starts when a configuration update listing the OSN-New is finalized by the existing cluster and delivered to the OSN-New.
+
+|Step|Component & Trace|Action Description|
+|:--|:--|:--|
+|**0.1**|`Registrar.JoinChannel(ChannelID, ConfigBlock)`|The new node receives the Config Block, which includes the updated list of `Consenters` in the Orderer configuration section.|
+|**0.2**|`etcdraft.Consenter.IsChannelMember(joinBlock)`|The Raft Consenter checks if the node's local certificate (`c.Cert`) is listed among the `Consenters` in the configuration block. This must be true for the node to proceed as a member.|
+|**0.3**|`Consenter.HandleChain(...)`|The Registrar calls the Raft `Consenter.HandleChain` method to begin the channel setup.|
+
+## Step 1: Raft Chain Initialization and ID Detection
+
+The `HandleChain` function initializes the `etcdraft.Chain` object and determines the node's unique role and identity within the cluster.
+
+|Step|Component & Trace|Action Description|
+|:--|:--|:--|
+|**1.1**|`etcdraft.ReadBlockMetadata(metadata, m)`|Metadata is restored from the last committed block or initialized if it's a migration. This metadata maps consenter certificates to their unique **Raft Node IDs**.|
+|**1.2**|`c.detectSelfID(consenters)`|The node identifies its numerical `RaftID` by matching its local certificate against the consenter map created in Step 1.1.|
+|**1.3**|`NewChain(...)`|The `etcdraft.Chain` structure is created, loaded with the last block, the Raft metadata (`BlockMetadata`), and the **`cluster.Communicator`** (`c.Comm` in the `Consenter` object).|
+
+## Step 2: Cluster Service Configuration (gRPC Activation)
+
+The Raft chain uses the `cluster.Communicator` to establish secure, authenticated gRPC connections to its peers.
+
+|Step|Component & Trace|Action Description|
+|:--|:--|:--|
+|**2.1**|Implicit Configuration via `NewChain`|The `NewChain` function is provided with the `cluster.Communicator` (Comm) instance. Although the source does not show a direct `c.Comm.Configure()` call within `NewChain` as explicitly as in the BFT examples, the `Comm` object is available and used by the `RPC` interface.|
+|**2.2**|`RPC` Initialization|The `etcdraft.Chain` initializes its **`RPC`** component (which uses `c.Comm` internally) and wraps it in a **`Disseminator`**.|
+|**2.3**|`Disseminator` Wrapping|The `Disseminator` wraps the `RPC` interface to enable **piggybacking cluster metadata** onto egress messages.|
+|**Result**|Secure Topology|The underlying `AuthCommMgr` establishes mTLS gRPC connections to all peers based on the consenter list, allowing consensus messages to flow securely.|
+
+## Step 3: Raft Node Startup and Message Pipelining
+
+The Raft protocol FSM (Finite State Machine) is initialized and started, usually campaigning to elect a leader if necessary.
+
+|Step|Component & Trace|Action Description|
+|:--|:--|:--|
+|**3.1**|`NewChain(...)` -> `raft.Node.Start(...)`|The `Chain` initializes the core `go.etcd.io/etcd/raft/v3.Node` object. Since the node is joining, it is started with `raft.RestartNode` if data exists, or potentially campaigns if starting fresh and designated.|
+|**3.2**|**Raft Readiness Loop**|The `node.start` routine enters a loop waiting on the `n.Ready()` channel.|
+|**3.3**|`n.send(rd.Messages)`|When `Ready()` outputs messages (`rd.Messages`), the node's `send` function is called. This function marshals the Raft message and calls the `Disseminator.SendConsensus`.|
+|**Action**|**gRPC Dispatch**|The `Disseminator` injects cluster metadata (e.g., active nodes list) into the `orderer.ConsensusRequest` if the destination node hasn't received it yet. It then uses the underlying `cluster.RPC` to send the `ConsensusRequest` over gRPC.|
+
+## Step 4: Synchronization and Log Catch-Up
+
+The OSN-New discovers it is behind the cluster and initiates the block retrieval process.
+
+|Step|Component & Trace|Action Description|
+|:--|:--|:--|
+|**4.1**|Raft Core Detection|If the node starts with a state behind the cluster (e.g., after loading an old snapshot), the Raft core signals the need to catch up.|
+|**4.2**|`c.catchUp(snap)`|If synchronization is needed (triggered by a snapshot or missing log entries), the `catchUp` routine is executed.|
+|**4.3**|`c.createPuller()`|The chain creates a **`BlockPuller`** object. This component relies on the Cluster Service's network capabilities (gRPC Deliver streams) but is separate from the `RPC` used for consensus messages.|
+|**4.4**|`puller.PullBlock(next)`|The `BlockPuller` creates a signed `DELIVER_SEEK_INFO` envelope and requests missing blocks from peers over a gRPC stream.|
+|**4.5**|`c.writeBlock(block, index)`|As missing blocks are received and validated, they are written to the local ledger.|
+
+## Step 5: Active FSM Participation and Client Submission
+
+Once synchronized, the node joins the active `run` loop, ready to process transactions and participate in elections.
+
+|Step|Function Call & Component|Action Description|
+|:--|:--|:--|
+|**5.1**|`c.run()` Loop Activation|The main `select` loop starts running, monitoring channels like `c.submitC` and `c.applyC`.|
+|**5.2**|`Chain.Submit(req, sender)`|A client submits a transaction request (`SubmitRequest`). The function checks the leader ID (`soft.Lead`).|
+|**Action**|Forwarding|If the OSN-New is not the leader (`lead != c.raftID`), it forwards the request using the Cluster Service: **`c.forwardToLeader(lead, req)`**. This ultimately calls `c.rpc.SendSubmit(lead, req, report)`.|
+|**Action**|Full Participation|If OSN-New becomes the leader, it proposes batches (`c.propose`) to the Raft FSM, which then replicates the block data using gRPC streams managed by the `AuthCommMgr`.|
+|**5.3**|**Reconfiguration**|If a configuration block commits, `c.writeConfigBlock` detects membership changes, updates local metadata (`c.opts.BlockMetadata`, `c.opts.Consenters`), and calls **`c.configureComm()`** which ensures the `AuthCommMgr` topology is updated.|
+
+This structure ensures that the etcdraft protocol operates solely on logical states and IDs, while the Cluster Service handles the complex, concurrent, and secure transmission of messages between nodes via gRPC.
+
+---
+
+
+Here is a detailed explanation drawing upon the provided SmartBFT and Fabric architecture sources.
+
+## I. Commitment of the Configuration Block (The Precondition)
+
+The statement is fundamentally **correct**: The Config Block that grants the new node membership must be finalized (ordered and committed) by the existing ordering service cluster **before** the new node can initialize its communication channels via `c.Comm.Configure(...)`.
+
+### 1. The Block Must Exist and Be Agreed Upon
+
+Hyperledger Fabric is a permissioned blockchain where the identities and roles of all participating nodes are known and registered with a Membership Service Provider (MSP). Configuration (including the list of `Consenters`) is part of the blockchain and must be agreed upon by the network.
+
+- **Consensus on Configuration:** The process of changing the membership (adding the new ordering node) requires a Configuration Transaction to be proposed, ordered by the existing ordering service, and packaged into a Configuration Block.
+- **The "Decision":** For SmartBFT, the block and the signatures from a quorum of ordering nodes ($Q=2F+1$) form the "decision". This decision signifies consensus has been reached on the new configuration.
+
+### 2. How the New Node Receives the Committed Block
+
+The joining process for the new consenter (OSN-New) starts when it receives this committed Config Block, typically via the **Channel Participation API** (`Registrar.JoinChannel`).
+
+- **Chain Initialization:** The `Registrar` uses this Config Block to initialize the ledger resources and call `Consenter.HandleChain`.
+- **Membership Check:** During `HandleChain`, the new node uses the Config Block to run `IsChannelMember` to determine if it is authorized to join.
+- **Configuration Trigger:** Only after the local node confirms it is a member and has the Config Block's data written to the ledger (via `ledgerRes.Append(configBlock)`), does it extract the configuration data (`RemoteNodes`) and call **`c.Comm.Configure(...)`**.
+
+The `c.Comm.Configure` call is a local administrative action on the OSN-New to **establish outbound gRPC connections** to the peers listed in that already-committed Config Block. It does not send the block to the network.
+
+## II. Who Proposed the Configuration Block? (The Client)
+
+In the context of the Fabric architecture, the entity that originates the Configuration Transaction and submits it for ordering is always a **Client**.
+
+The flow of a transaction (including a Configuration Transaction) is client-driven:
+
+### 1. The Proposer Role: The Client (SDK Application)
+
+A Configuration Block is initiated when an administrative **Client** (using the Fabric SDK or administrative tools) creates and proposes a Configuration Transaction.
+
+- **Transaction Flow:** The client first creates and signs a transaction proposal. This proposal is sent to endorsing peers for simulation and endorsement.
+- **Endorsed Transaction:** The client waits for sufficient endorsements. Once collected, the client creates the final, endorsed transaction (containing the header, payload, read-write sets, and signatures).
+- **Submission to Orderer:** The client then **submits the transaction to the ordering service**.
+
+### 2. Special Role of Configuration Transactions
+
+Configuration Transactions are treated specially during ordering and block creation:
+
+- **Submission:** The client submits the configuration transaction to the ordering service using the `Configure` function on the orderer side.
+- **Block Assembly:** The leader OSN, using the **`Assembler`** component, is specifically mandated to ensure that a configuration transaction **must reside in a block by itself**. The leader assembles this transaction into the next block, which becomes the Configuration Block.
+- **Consensus:** This Configuration Block is then proposed to the cluster (using SmartBFT's PRE-PREPARE phase, for instance), ordered, and committed.
+
+Thus, the **Client** (an authorized administrator application using the Fabric SDK) is the entity that proposes the underlying Configuration Transaction that ultimately becomes the committed Config Block.
+
+### Summary of Roles
+
+| Entity                      | Role in Adding OSN-New                                                                                                                                        |
+| :-------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Client**                  | Proposes and submits the Configuration **Transaction** to the existing ordering cluster.                                                                      |
+| **Existing Orderer Quorum** | Orders the transaction, creates the **Configuration Block**, and achieves consensus ($2F+1$ signatures).                                                      |
+| **OSN-New (Joining Node)**  | Receives the **committed** Config Block, validates its membership, and uses the block to call `c.Comm.Configure` to set up its gRPC connections to its peers. |
+
+----
+
+This is an excellent question that gets to the heart of how Fabric maintains a dynamically managed, secure cluster. For the existing ordering nodes (consenters) to recognize that a "friend joined," they do not rely on a notification from the new node; instead, they rely on **their own commitment process** of the Configuration Block.
+
+The existing consenters (let's call them OSN A, B, and C) learn about the new consenter (OSN-New) and update their communication channels via a coordinated, internal architectural function known as **dynamic reconfiguration**.
+
+Here is the step-by-step process of how the existing members update their view of the cluster using the SmartBFT architecture:
+
+## I. The Trigger: Commitment of the Configuration Block
+
+The crucial difference in a blockchain system is that communication topology is determined by data committed to the shared ledger.
+
+1. **Client Submits the Change:** An authorized administrative client submits a **Configuration Transaction** that includes OSN-New's identity, endpoint, and certificates into the `Consenters` list.
+2. **Consensus Achieved:** The existing ordering nodes (A, B, C) process this transaction through the SmartBFT consensus protocol (reaching the commit/decide phases).
+3. **Local Commitment:** OSNs A, B, and C all commit this new **Configuration Block** to their local ledgers via the `Deliver` function. This commitment is the definitive proof that the topology change is official and agreed upon by the necessary quorum.
+
+## II. The Action: Invoking the `Configure` Method
+
+Immediately after committing the Configuration Block, the Fabric wrapper layer on each existing OSN executes a hook to update its runtime configuration.
+
+### A. The Hook Function Call
+
+The SmartBFT chain calls an internal function (`updateRuntimeConfig` or similar logic) which detects that a configuration block was committed.
+
+1. **Membership Extraction:** The function parses the newly committed Configuration Block and extracts the complete, updated list of `Consenters` (which now includes OSN-New, identified by its ID and certificates).
+2. **Communication Configuration:** The chain wrapper calls the Cluster Service's topology manager using this new list of members:
+    
+    ```
+    c.Comm.Configure(c.Channel, newRTC.RemoteNodes)
+    ```
+    
+
+### B. The Dual Role of `AuthCommMgr.Configure`
+
+The `c.Comm.Configure` method performs two crucial tasks on the **local node** (OSN A, B, or C) to recognize OSN-New:
+
+#### 1. Egress (Outbound) Connection Activation
+
+The `AuthCommMgr` detects that OSN-New is a **new member** in the `RemoteNodes` list and is not currently represented by an active gRPC connection stub.
+
+- The `AuthCommMgr` iterates over the `RemoteNode` list and calls `ac.updateStubInMapping` for OSN-New.
+- This triggers `ac.Connections.Connect(OSN_New_Endpoint, OSN_New_ServerRootCA)`.
+- **Result:** The existing ordering node (e.g., OSN A) establishes a new, secure **gRPC stream** to OSN-New, preparing to send consensus messages to it.
+
+#### 2. Ingress (Inbound) Authentication Update
+
+The existing node must update its **server-side** authentication rules so that when OSN-New attempts to connect _back_ to A, B, or C, its cryptographic identity is recognized as valid.
+
+- The `BFTChain` calls `c.clusterService.ConfigureNodeCerts(c.Channel, newRTC.consenters)`.
+- The `ClusterService` (which manages the inbound gRPC server) updates its internal `MemberMapping` cache, registering the sanitized certificate of OSN-New and mapping it to its known ID.
+- **Result:** When OSN-New starts running and attempts to establish its own set of connections (Step 3 on OSN-New), the existing nodes can successfully verify its mTLS certificate and cryptographic identity.
+
+## III. The Network Result
+
+By simultaneously executing this `Configure` process after committing the Config Block, every existing node proactively establishes a secure channel to the new consenter, and registers the new consenter's identity for inbound authentication.
+
+Crucially, **the membership verification policy is also updated dynamically**. The new **BFT validation policy** now knows that the required quorum $Q$ must be drawn from the updated set of consenters (A, B, C, and New), ensuring BFT security is maintained across the new cluster size.
+
+In essence, the existing orderers know "a friend joined" because they all agreed, cryptographically, on the ledger that the friend was invited, and they immediately adjusted their local network management system (`AuthCommMgr`) to shake hands over gRPC.
+
+---
+
+That is an excellent focus. To implement the basic **Join and Leave** functionality using the `AuthCommMgr` in the BDLS POC, you need to rely on the established Fabric architectural pattern used by both Raft and SmartBFT: **Dynamic Reconfiguration**.
+
+The key insight is that `AuthCommMgr` handles all the complex network I/O, mTLS setup, and connection teardown. The consensus layer simply needs to tell the `AuthCommMgr` **who the current members are** whenever the channel configuration changes.
+
+Based on the source code provided for the BDLS POC and the architecture of the Cluster Service, here is the detailed plan for implementing Join and Leave using the `AuthCommMgr`.
+
+---
+
+## Phase 3: Implementing Join and Leave via `AuthCommMgr`
+
+The `AuthCommMgr` implements the `cluster.Communicator` interface, specifically the **`Configure(channel string, members []RemoteNode)`** method. This method is designed to manage the cluster topology dynamically.
+
+### Step 3.1: Enabling the Join Operation (Node Startup)
+
+The Join operation occurs when a new ordering node (OSN-New) starts serving a channel. The BDLS POC is already correctly configured to execute the core logic for this:
+
+1. **Configuration Check:** During the channel creation process (`bdls.Consenter.HandleChain`), the BDLS consenter determines its `selfID` by checking its identity against the consenter list in the configuration block.
+2. **Remote Peer Extraction:** The `bdls.Chain.NewChain` function calls `c.remotePeers()`. This helper function extracts the IDs, endpoints, and certificates of **all** current consenters from the channel configuration.
+3. **Activation Call:** The `NewChain` function explicitly calls `c.Comm.Configure`:
+    
+    ```
+    // In bdls/chain.go
+    c.Comm.Configure(c.support.ChannelID(), nodes)
+    ```
+    
+    - **Mechanism:** When OSN-New calls `Configure`, the `AuthCommMgr` compares the `nodes` list against its current connections (which are none, as the node is new). It then iterates over the list and proactively attempts to **`Activate`** a `Stub` and establish a **gRPC connection** (via `ConnectionsMgr.Connect`) to every other peer in the cluster. This successfully implements the **JOIN** operation by opening secure outbound communication channels.
+
+### Step 3.2: Enabling the Leave Operation (Topology Update)
+
+The Leave operation, or any reconfiguration (adding, removing, or rotating nodes), is triggered when a **Configuration Block** is committed to the ledger.
+
+1. **The Trigger: `Deliver` and `updateRuntimeConfig`**
+    
+    - The BDLS chain wrapper must implement a hook that executes immediately after a block is committed. In the SmartBFT model, this is the `Deliver` function calling `c.updateRuntimeConfig(block)`.
+    - **Action:** When a Configuration Block is received and committed (written to the ledger) via `c.support.WriteConfigBlock`, the `updateRuntimeConfig` function executes.
+2. **Detection and Reconfiguration (The Key Function)** The `updateRuntimeConfig` logic (which you would need to fully implement in the BDLS chain wrapper, referencing the SmartBFT pattern) must perform two essential actions:
+    
+    - **a. Update Outbound Communication (`AuthCommMgr`):** It extracts the `RemoteNodes` list from the new configuration and calls `c.Comm.Configure`:
+        
+        ```
+        if protoutil.IsConfigBlock(block) {
+            c.Comm.Configure(c.Channel, newRTC.RemoteNodes) //
+        // ...
+        }
+        ```
+        
+        - **Mechanism:** When `AuthCommMgr.Configure` is called with a new member list (`members`), it compares this list against the old mapping (`Chan2Members`). If a node (OSN-Old) is missing from the new list:
+            - The code detects that OSN-Old is not in `newNodeIDs`.
+            - It calls `mapping.Remove(id)` and `stub.Deactivate()`.
+            - It calls `ac.Connections.Disconnect(stub.Endpoint)`, which closes the secure gRPC connection to the leaving node. This implements the **LEAVE** operation by tearing down the outbound connection.
+    - **b. Update Inbound Authentication (`ClusterService`):** The existing nodes (A, B, C) must update their server-side certificates to authenticate new incoming connections (OSN-New) and reject evicted nodes (OSN-Old).
+        
+        ```
+        c.clusterService.ConfigureNodeCerts(c.Channel, newRTC.consenters) //
+        ```
+        
+        - **Mechanism:** The `cluster.ClusterService` holds the authentication state for its gRPC server. `ConfigureNodeCerts` updates the `MembershipByChannel` mapping, which is used during stream negotiation (`ClusterService.Step`) to verify that the incoming client certificate belongs to a known consenter in the channel. This step is vital for ensuring secure, permissioned communication.
+
+### Step 3.3: Clean Up Custom Networking Conflicts
+
+While the `AuthCommMgr.Configure` calls listed above enable the logical Join/Leave, the existing **custom TCP implementation** in the BDLS POC directly conflicts with this.
+
+To ensure that the `AuthCommMgr` is the sole authority for network state, the following must be removed from the BDLS Chain code:
+
+1. **Remove Custom Transport Initialization:** Delete the code block in `c.startConsensus` that sets up hardcoded peers and the custom `transportLayer *agent.TCPAgent`.
+2. **Remove Custom Connection Loops:** Delete the goroutines responsible for passive and active TCP connections (listening via `l.Accept()` and connecting via `net.Dial`). These are redundant to the `AuthCommMgr` connections.
+3. **Remove Polling:** Delete the `updateTick := time.NewTicker(updatePeriod)` and the `c.transportLayer.Update()` call loop. This polling mechanism is tied to the custom TCP stack and violates the Fabric event model.
+
+By executing these steps, the BDLS chain relies entirely on the properly configured `c.Comm` (AuthCommMgr) and `c.ClusterService` for all membership, authentication, and connection lifecycle management, successfully implementing basic Join and Leave functionality via standard Fabric interfaces.
+
+---
+
+The `Ingress` component in SmartBFT serves as the **dispatcher** or entry point for external messages—both consensus-related communications and client transaction submissions—received by a Hyperledger Fabric Ordering Service Node (OSN) that is running the SmartBFT consensus library.
+
+The architecture relies on the `Ingress` component to translate generic gRPC requests received by the OSN cluster service into specific API calls processed by the underlying SmartBFT consensus logic for a particular channel.
+
+Here is a detailed breakdown of how `Ingress` works in SmartBFT, who calls its methods, and what each method does:
+
+### 1. Structure and Purpose of `Ingress`
+
+The `Ingress` struct in SmartBFT is designed to decouple the cluster communication layer from the channel-specific consensus implementation.
+
+The `Ingress` structure contains:
+
+- **`Logger`**: For logging warnings and errors.
+- **`ChainSelector`**: An interface (`ReceiverGetter`) used to find the correct SmartBFT chain (`MessageReceiver`) corresponding to the channel ID specified in the incoming message.
+
+The `Ingress` must implement the `Handler` interface, which defines methods for handling consensus and submission requests received over the cluster communication layer.
+
+### 2. Who Calls the `Ingress` Methods?
+
+The methods of the `Ingress` component are primarily called by the **Cluster Service implementation** running on the Hyperledger Fabric OSN.
+
+When an orderer receives a request from another node (either another orderer or a client/peer interacting with the cluster via the `Step` service), the Cluster Service handles the low-level gRPC communication and then calls the `Ingress` handler to determine where to route the payload.
+
+Specifically, the `ClusterService` (or similar high-level communication dispatching mechanism) calls the `Ingress` methods:
+
+- If the incoming request is a general **consensus message** (e.g., a BFT `PRE-PREPARE` or `COMMIT` message wrapped in a Fabric `ConsensusRequest`), the Cluster Service calls `OnConsensus`.
+- If the incoming request is a client **transaction submission** (wrapped in a Fabric `SubmitRequest`), the Cluster Service calls `OnSubmit`.
+
+### 3. Methods of the `Ingress` and Their Actions
+
+The `Ingress` component implements two main methods, corresponding to the two types of messages it handles:
+
+#### A. `OnConsensus(channel string, sender uint64, request *ab.ConsensusRequest) error`
+
+This method processes messages related to the internal BFT consensus protocol flow.
+
+|Step|Action|Source Support|
+|:--|:--|:--|
+|**1. Locate Receiver**|It uses the `ChainSelector` (which often points back to the main Consenter) to retrieve the specific `MessageReceiver` (i.e., the `BFTChain` instance) responsible for the given `channel` ID. If the channel does not exist, it logs a warning and returns an error.||
+|**2. Unmarshal Payload**|It unmarshals the raw payload contained within the Fabric `ConsensusRequest` (`request.Payload`) into a **SmartBFT consensus message structure** (`protos.Message`).||
+|**3. Delegate to Chain**|It calls the underlying consensus chain's implementation: **`receiver.HandleMessage(sender, msg)`**. This transfers the SmartBFT-specific consensus message directly to the logic responsible for driving the BFT state machine (`c.consensus.HandleMessage(sender, m)`).||
+
+#### B. `OnSubmit(channel string, sender uint64, request *ab.SubmitRequest) error`
+
+This method processes incoming client transaction proposals submitted to the orderer.
+
+|Step|Action|Source Support|
+|:--|:--|:--|
+|**1. Locate Receiver**|Similar to `OnConsensus`, it uses the `ChainSelector` to locate the target `MessageReceiver` (the `BFTChain` instance) for the specified `channel`. If the channel does not exist, it logs a warning and returns an error.||
+|**2. Extract Payload**|It extracts the client payload (the Fabric `Envelope`) contained within the `SubmitRequest` (`request.Payload`) and marshals it into raw bytes.||
+|**3. Delegate to Chain**|It calls the underlying consensus chain's implementation: **`receiver.HandleRequest(sender, protoutil.MarshalOrPanic(request.Payload))`**. This is critical because the **`HandleRequest`** function in the BFT chain:|
+
+```
+*   First, calls the application's verification logic (`c.verifier.VerifyRequest(req)`) to check the request's validity and authorization before involving the core consensus logic.
+*   If verified, it passes the request to the SmartBFT consensus core: `c.consensus.SubmitRequest(req)`. | |
+```
+
+In summary, the **`Ingress`** component acts as the **Layer 7 gateway** in the Hyperledger Fabric OSN, taking high-level communication streams (handled by the Cluster Service) and routing specific types of messages (consensus updates via `OnConsensus` and client inputs via `OnSubmit`) to the appropriate consensus state machine for processing.


### PR DESCRIPTION
This document presents a detailed technical analysis and refactor plan for integrating **BDLS (Blockchain DLS)** consensus into the **Hyperledger Fabric** framework using Fabric’s native **gRPC-based Cluster Service** instead of the current **raw TCP transport**.
It summarizes the architectural differences, missing integrations, and the steps required to align BDLS with Fabric’s production-ready communication infrastructure.

---

## **Key Findings**

* **Current Limitation:** The BDLS Proof of Concept currently uses a custom `agent-tcp` transport that bypasses Fabric’s `cluster.RPC` and `AuthCommMgr` infrastructure.
* **Architecture Analysis:** Compared and contrasted BDLS, SmartBFT, and etcdraft communication models, confirming Fabric’s transport layer is fully gRPC-driven.
* **Identified Bottleneck:** The BDLS `PeerInterface` tightly couples the consensus logic with network-level code, blocking clean integration with Fabric’s cluster service.
* **Security Gaps:** BDLS currently reimplements authentication via **ECDH/HMAC over TCP** instead of leveraging Fabric’s **TLS-based authenticated channels**.

---

## **Proposed Refactor**

1. **Remove Custom TCP Agent:**
   Eliminate `agent.TCPAgent` and related networking logic from `chain.go`.

2. **Adopt Fabric gRPC Transport:**
   Use Fabric’s `cluster.Communicator` and `cluster.RPC` for inter-node messaging (`SendConsensus`).

3. **Implement Fabric-Compatible Egress/Ingress:**

   * Redirect all BDLS message broadcasting through `Egress.SendConsensus`.
   * Use the existing Fabric `ClusterService` for inbound messages (`Ingress.OnConsensus`).

4. **Modify BDLS Core:**
   Replace `PeerInterface` with a transport-agnostic `Transmitter` interface for ID-based message delivery.

5. **Integrate Secure Auth:**
   Leverage Fabric’s `AuthCommMgr` for authenticated, TLS-bound gRPC channels.
